### PR TITLE
[codex] fix startup cleanup and cover CLI flow

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -26,11 +26,12 @@ type Broadcaster struct {
 	conf Config
 	log  *slog.Logger
 
-	announcer   *room.XBLAnnouncer
-	listener    *minecraft.Listener
-	signaling   nethernet.Signaling
-	sessionRef  mpsd.SessionReference
-	subSessions []*mpsd.Session
+	announcer        room.Announcer
+	listener         *minecraft.Listener
+	signaling        nethernet.Signaling
+	sessionRef       mpsd.SessionReference
+	subSessions      []*mpsd.Session
+	announcerFactory func(*Broadcaster) room.Announcer
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -91,7 +92,8 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	b.announcer = b.newAnnouncer()
 	if err := b.announcer.Announce(b.ctx, status); err != nil {
 		b.cancel()
-		return fmt.Errorf("announce session: %w", err)
+		err = errors.Join(fmt.Errorf("announce session: %w", err), b.cleanupStartupFailure(true))
+		return err
 	}
 	if err := b.startSubAccounts(b.ctx); err != nil {
 		b.cancel()
@@ -145,8 +147,8 @@ func (b *Broadcaster) friendSyncer() FriendSyncer {
 		History: b.conf.FriendHistory,
 		Log:     b.log,
 	}
-	if b.announcer != nil && b.announcer.Session != nil {
-		syncer.Inviter = sessionInviter{session: b.announcer.Session}
+	if announcer, ok := b.announcer.(*room.XBLAnnouncer); ok && announcer.Session != nil {
+		syncer.Inviter = sessionInviter{session: announcer.Session}
 	}
 	return syncer
 }
@@ -187,7 +189,10 @@ func (b *Broadcaster) signalingFor(ctx context.Context) (nethernet.Signaling, er
 	return d.DialContext(ctx, b.conf.LiveTokenSource)
 }
 
-func (b *Broadcaster) newAnnouncer() *room.XBLAnnouncer {
+func (b *Broadcaster) newAnnouncer() room.Announcer {
+	if b.announcerFactory != nil {
+		return b.announcerFactory(b)
+	}
 	ref := mpsd.SessionReference{
 		ServiceConfigID: serviceConfigUUID,
 		TemplateName:    TemplateName,

--- a/cmd/broadcaster/main.go
+++ b/cmd/broadcaster/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -12,9 +14,32 @@ import (
 	"syscall"
 
 	"github.com/HashimTheArab/go-mcxboxbroadcast"
+	"github.com/df-mc/go-xsapi"
 	"github.com/sandertv/gophertunnel/minecraft/auth"
 	"golang.org/x/oauth2"
 )
+
+type commandOptions struct {
+	ConfigPath string
+	Debug      bool
+}
+
+type commandBroadcaster interface {
+	Start(context.Context) error
+	Close() error
+}
+
+type commandDeps struct {
+	Stdout             io.Writer
+	HTTPClient         *http.Client
+	LoadConfig         func(string) (broadcaster.ConfigFile, error)
+	LoadLiveToken      func(string) (*oauth2.Token, error)
+	NewLiveTokenSource func(*oauth2.Token, io.Writer) oauth2.TokenSource
+	SaveLiveToken      func(string, *oauth2.Token) error
+	LoadAccountToken   func(string, io.Writer) (oauth2.TokenSource, error)
+	NewXBLTokenSource  func(context.Context, oauth2.TokenSource) xsapi.TokenSource
+	NewBroadcaster     func(broadcaster.Config) (commandBroadcaster, error)
+}
 
 func main() {
 	var (
@@ -23,90 +48,150 @@ func main() {
 	)
 	flag.Parse()
 
-	cfg, err := broadcaster.LoadConfigFile(*configPath)
-	if err != nil {
-		slog.Error("load config", "err", err)
-		os.Exit(1)
-	}
-	level := slog.LevelInfo
-	if *debug || cfg.DebugMode {
-		level = slog.LevelDebug
-	}
-	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	baseDir := filepath.Dir(*configPath)
+	if err := runBroadcasterCommand(ctx, commandOptions{ConfigPath: *configPath, Debug: *debug}, defaultCommandDeps()); err != nil {
+		slog.Error("broadcaster", "err", err)
+		os.Exit(1)
+	}
+}
+
+func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps commandDeps) error {
+	deps = deps.withDefaults()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if opts.ConfigPath == "" {
+		opts.ConfigPath = "config.yml"
+	}
+	cfg, err := deps.LoadConfig(opts.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	level := slog.LevelInfo
+	if opts.Debug || cfg.DebugMode {
+		level = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(deps.Stdout, &slog.HandlerOptions{Level: level}))
+
+	baseDir := filepath.Dir(opts.ConfigPath)
 	cachePath := resolveConfigPath(baseDir, cfg.Accounts.PrimaryCachePath)
-	tok, err := broadcaster.LoadLiveToken(cachePath)
+	if err := validateSubAccountCachePaths(baseDir, cachePath, cfg.Accounts.SubAccounts); err != nil {
+		return err
+	}
+
+	tok, err := deps.LoadLiveToken(cachePath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Warn("could not load token cache", "err", err)
 	}
-	live := auth.RefreshTokenSourceWriter(tok, os.Stdout)
+	live := deps.NewLiveTokenSource(tok, deps.Stdout)
 	tok, err = live.Token()
 	if err != nil {
-		log.Error("authenticate", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("authenticate: %w", err)
 	}
-	if err := broadcaster.SaveLiveToken(cachePath, tok); err != nil {
+	if err := deps.SaveLiveToken(cachePath, tok); err != nil {
 		log.Warn("could not save token cache", "err", err)
 	}
 
 	runtime, err := cfg.RuntimeConfig(broadcaster.RuntimeConfigInput{
-		TokenSource:     broadcaster.NewXBLTokenSource(ctx, live),
+		TokenSource:     deps.NewXBLTokenSource(ctx, live),
 		LiveTokenSource: live,
-		HTTPClient:      http.DefaultClient,
+		HTTPClient:      deps.HTTPClient,
 		Log:             log,
 		BaseDir:         baseDir,
 	})
 	if err != nil {
-		log.Error("configure", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("configure: %w", err)
 	}
-	accountCachePaths := map[string]string{cachePath: "primary"}
 	for _, account := range cfg.Accounts.SubAccounts {
 		if !account.Enabled {
 			continue
 		}
 		subCachePath, err := subAccountCachePath(baseDir, account)
 		if err != nil {
-			log.Error("configure sub-account", "id", account.ID, "err", err)
-			os.Exit(1)
+			return fmt.Errorf("configure sub-account %q: %w", account.ID, err)
 		}
-		if owner, ok := accountCachePaths[subCachePath]; ok {
-			log.Error("duplicate account cache path", "id", account.ID, "owner", owner, "path", subCachePath)
-			os.Exit(1)
-		}
-		accountCachePaths[subCachePath] = account.ID
-		subLive, err := loadAccountToken(subCachePath, os.Stdout)
+		subLive, err := deps.LoadAccountToken(subCachePath, deps.Stdout)
 		if err != nil {
-			log.Error("authenticate sub-account", "id", account.ID, "err", err)
-			os.Exit(1)
+			return fmt.Errorf("authenticate sub-account %q: %w", account.ID, err)
 		}
 		runtime.SubAccounts = append(runtime.SubAccounts, broadcaster.SubAccountConfig{
 			ID:          account.ID,
 			Enabled:     true,
-			TokenSource: broadcaster.NewXBLTokenSource(ctx, subLive),
+			TokenSource: deps.NewXBLTokenSource(ctx, subLive),
 		})
 	}
 
-	b, err := broadcaster.New(runtime)
+	b, err := deps.NewBroadcaster(runtime)
 	if err != nil {
-		log.Error("configure", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("configure broadcaster: %w", err)
 	}
 	if err := b.Start(ctx); err != nil {
-		log.Error("start", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("start: %w", err)
 	}
 	log.Info("broadcasting", "target", runtime.Server.Address())
 
 	<-ctx.Done()
 	if err := b.Close(); err != nil {
-		log.Error("close", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("close: %w", err)
 	}
+	return nil
+}
+
+func defaultCommandDeps() commandDeps {
+	return commandDeps{}
+}
+
+func (d commandDeps) withDefaults() commandDeps {
+	if d.Stdout == nil {
+		d.Stdout = os.Stdout
+	}
+	if d.HTTPClient == nil {
+		d.HTTPClient = http.DefaultClient
+	}
+	if d.LoadConfig == nil {
+		d.LoadConfig = broadcaster.LoadConfigFile
+	}
+	if d.LoadLiveToken == nil {
+		d.LoadLiveToken = broadcaster.LoadLiveToken
+	}
+	if d.NewLiveTokenSource == nil {
+		d.NewLiveTokenSource = auth.RefreshTokenSourceWriter
+	}
+	if d.SaveLiveToken == nil {
+		d.SaveLiveToken = broadcaster.SaveLiveToken
+	}
+	if d.LoadAccountToken == nil {
+		d.LoadAccountToken = loadAccountToken
+	}
+	if d.NewXBLTokenSource == nil {
+		d.NewXBLTokenSource = broadcaster.NewXBLTokenSource
+	}
+	if d.NewBroadcaster == nil {
+		d.NewBroadcaster = func(conf broadcaster.Config) (commandBroadcaster, error) {
+			return broadcaster.New(conf)
+		}
+	}
+	return d
+}
+
+func validateSubAccountCachePaths(base, primaryCachePath string, accounts []broadcaster.SubAccountFile) error {
+	owners := map[string]string{primaryCachePath: "primary"}
+	for _, account := range accounts {
+		if !account.Enabled {
+			continue
+		}
+		subCachePath, err := subAccountCachePath(base, account)
+		if err != nil {
+			return fmt.Errorf("configure sub-account %q: %w", account.ID, err)
+		}
+		if owner, ok := owners[subCachePath]; ok {
+			return fmt.Errorf("duplicate account cache path for %q and %q: %s", owner, account.ID, subCachePath)
+		}
+		owners[subCachePath] = account.ID
+	}
+	return nil
 }
 
 func defaultCachePath() string {
@@ -117,7 +202,7 @@ func defaultCachePath() string {
 	return filepath.Join(dir, "mcxboxbroadcast-go", "live_token.json")
 }
 
-func loadAccountToken(path string, out *os.File) (oauth2.TokenSource, error) {
+func loadAccountToken(path string, out io.Writer) (oauth2.TokenSource, error) {
 	tok, err := broadcaster.LoadLiveToken(path)
 	if err != nil {
 		tok = nil

--- a/cmd/broadcaster/main_test.go
+++ b/cmd/broadcaster/main_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"io"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	broadcaster "github.com/HashimTheArab/go-mcxboxbroadcast"
+	"github.com/df-mc/go-xsapi"
+	"golang.org/x/oauth2"
 )
 
 func TestSubAccountCachePathUsesExplicitPath(t *testing.T) {
@@ -35,4 +41,119 @@ func TestSubAccountCachePathRequiresIDWhenPathOmitted(t *testing.T) {
 	if _, err := subAccountCachePath("/base", broadcaster.SubAccountFile{}); err == nil {
 		t.Fatal("expected error")
 	}
+}
+
+func TestRunBroadcasterCommandRejectsDuplicateSubAccountCacheBeforeAuth(t *testing.T) {
+	var authenticated bool
+	err := runBroadcasterCommand(context.Background(), commandOptions{
+		ConfigPath: "/base/config.yml",
+	}, commandDeps{
+		Stdout: io.Discard,
+		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
+			cfg := broadcaster.DefaultConfigFile()
+			cfg.Accounts.PrimaryCachePath = "cache/live_token.json"
+			cfg.Accounts.SubAccounts = []broadcaster.SubAccountFile{{
+				ID:        "alt",
+				Enabled:   true,
+				CachePath: "cache/live_token.json",
+			}}
+			return cfg, nil
+		},
+		NewLiveTokenSource: func(*oauth2.Token, io.Writer) oauth2.TokenSource {
+			authenticated = true
+			return staticOAuthTokenSource{}
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate account cache path") {
+		t.Fatalf("expected duplicate cache path error, got %v", err)
+	}
+	if authenticated {
+		t.Fatal("authenticated before rejecting duplicate sub-account cache path")
+	}
+}
+
+func TestRunBroadcasterCommandStartsAndClosesBroadcaster(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := false
+	closed := false
+	var gotSubAccounts int
+	err := runBroadcasterCommand(ctx, commandOptions{
+		ConfigPath: "/base/config.yml",
+	}, commandDeps{
+		Stdout: io.Discard,
+		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
+			cfg := broadcaster.DefaultConfigFile()
+			cfg.Session.RemoteAddress = "127.0.0.1"
+			cfg.Session.RemotePort = "19132"
+			cfg.Accounts.PrimaryCachePath = "cache/live_token.json"
+			cfg.Accounts.SubAccounts = []broadcaster.SubAccountFile{{
+				ID:      "alt",
+				Enabled: true,
+			}}
+			return cfg, nil
+		},
+		LoadLiveToken: func(string) (*oauth2.Token, error) {
+			return nil, errors.ErrUnsupported
+		},
+		NewLiveTokenSource: func(*oauth2.Token, io.Writer) oauth2.TokenSource {
+			return staticOAuthTokenSource{}
+		},
+		SaveLiveToken: func(string, *oauth2.Token) error {
+			return nil
+		},
+		LoadAccountToken: func(string, io.Writer) (oauth2.TokenSource, error) {
+			return staticOAuthTokenSource{}, nil
+		},
+		NewXBLTokenSource: func(context.Context, oauth2.TokenSource) xsapi.TokenSource {
+			return staticXBLTokenSource{}
+		},
+		NewBroadcaster: func(conf broadcaster.Config) (commandBroadcaster, error) {
+			gotSubAccounts = len(conf.SubAccounts)
+			return fakeCommandBroadcaster{
+				start: func(context.Context) error {
+					started = true
+					cancel()
+					return nil
+				},
+				close: func() error {
+					closed = true
+					return nil
+				},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !started || !closed {
+		t.Fatalf("started=%v closed=%v", started, closed)
+	}
+	if gotSubAccounts != 1 {
+		t.Fatalf("expected one sub-account, got %d", gotSubAccounts)
+	}
+}
+
+type staticOAuthTokenSource struct{}
+
+func (staticOAuthTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: "token"}, nil
+}
+
+type staticXBLTokenSource struct{}
+
+func (staticXBLTokenSource) Token() (xsapi.Token, error) {
+	return nil, nil
+}
+
+type fakeCommandBroadcaster struct {
+	start func(context.Context) error
+	close func() error
+}
+
+func (f fakeCommandBroadcaster) Start(ctx context.Context) error {
+	return f.start(ctx)
+}
+
+func (f fakeCommandBroadcaster) Close() error {
+	return f.close()
 }

--- a/integration_clients_test.go
+++ b/integration_clients_test.go
@@ -372,6 +372,32 @@ func TestStartupFailureCleanupClosesSignaling(t *testing.T) {
 	}
 }
 
+func TestStartCleansUpWhenPrimaryAnnounceFails(t *testing.T) {
+	announceErr := errors.New("announce failed")
+	sig := &fakeSignaling{}
+	announcer := &fakeAnnouncer{announceErr: announceErr}
+	b := &Broadcaster{
+		conf: Config{
+			Server:    ServerInfo{Host: "127.0.0.1", Port: 19132},
+			Signaling: sig,
+			Status:    Status{HostName: "Host", WorldName: "World"},
+		},
+		announcerFactory: func(*Broadcaster) room.Announcer {
+			return announcer
+		},
+	}
+	err := b.Start(context.Background())
+	if !errors.Is(err, announceErr) {
+		t.Fatalf("Start() error = %v, want announce error", err)
+	}
+	if !announcer.closed {
+		t.Fatal("announcer was not closed")
+	}
+	if !sig.closed {
+		t.Fatal("signaling was not closed")
+	}
+}
+
 func TestQueryStatusFallsBackToWeb(t *testing.T) {
 	status, err := queryStatusWithFallback(context.Background(), QueryOptions{
 		Address:            "127.0.0.1:1",
@@ -453,6 +479,20 @@ func (f fakeNotifier) Notify(ctx context.Context, message string) error {
 	if f.notify != nil {
 		f.notify(ctx, message)
 	}
+	return nil
+}
+
+type fakeAnnouncer struct {
+	announceErr error
+	closed      bool
+}
+
+func (f *fakeAnnouncer) Announce(context.Context, room.Status) error {
+	return f.announceErr
+}
+
+func (f *fakeAnnouncer) Close() error {
+	f.closed = true
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Clean up announcer and signaling resources when the primary Xbox announce step fails during startup.
- Add a focused regression test for primary announce failure cleanup.
- Extract the CLI command flow behind injectable dependencies and cover duplicate cache rejection plus start/close behavior.

## Validation

- `go test ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational and test-structure changes; no new auth protocols, but startup/signaling cleanup affects live session publishing reliability.
> 
> **Overview**
> Fixes **startup resource leaks** when the primary Xbox session announce fails: `Start` now runs the same `cleanupStartupFailure` path used for sub-account failures, closing the announcer and signaling. `Broadcaster` uses the `room.Announcer` interface plus an optional `announcerFactory` so integration tests can inject a fake announcer; friend-sync session inviting still targets `*room.XBLAnnouncer` via a type assert.
> 
> The **broadcaster CLI** is refactored into `runBroadcasterCommand` with injectable `commandDeps` (config load, tokens, HTTP client, `NewBroadcaster`). Duplicate primary/sub-account token cache paths are rejected in `validateSubAccountCachePaths` **before** authentication. `main` only maps errors to exit codes. New tests cover duplicate-cache rejection, happy-path start/close with a fake broadcaster, and announce-failure cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05ddd4e856f953a95be8b8af30d433ce1835197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved broadcaster command structure with enhanced modularity through dependency injection

* **Bug Fixes**
  * Enhanced error handling during broadcaster startup failures to ensure proper cleanup when announcements fail

* **Tests**
  * Added command-level tests for startup scenarios
  * Added integration tests for startup failure cleanup behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HashimTheArab/go-mcxboxbroadcast/pull/1?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->