### PR TITLE
[codex] add configurable HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The config exposes the same operator-facing areas as MCXboxBroadcast:
 - friend sync automation and expiry settings, including last-seen history path
 - Slack/Discord-compatible webhook notifications
 - primary and sub-account token cache paths
+- optional HTTP proxy URL through `http.proxy`
 
 ## Docker
 

--- a/cmd/broadcaster/main.go
+++ b/cmd/broadcaster/main.go
@@ -69,6 +69,14 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+	httpClient, err := cfg.HTTP.Client(deps.HTTPClient)
+	if err != nil {
+		return fmt.Errorf("configure http client: %w", err)
+	}
+	authCtx := ctx
+	if httpClient != nil {
+		authCtx = context.WithValue(authCtx, oauth2.HTTPClient, httpClient)
+	}
 	level := slog.LevelInfo
 	if opts.Debug || cfg.DebugMode {
 		level = slog.LevelDebug
@@ -95,9 +103,9 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 	}
 
 	runtime, err := cfg.RuntimeConfig(broadcaster.RuntimeConfigInput{
-		TokenSource:     deps.NewXBLTokenSource(ctx, live),
+		TokenSource:     deps.NewXBLTokenSource(authCtx, live),
 		LiveTokenSource: live,
-		HTTPClient:      deps.HTTPClient,
+		HTTPClient:      httpClient,
 		Log:             log,
 		BaseDir:         baseDir,
 	})
@@ -119,7 +127,7 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 		runtime.SubAccounts = append(runtime.SubAccounts, broadcaster.SubAccountConfig{
 			ID:          account.ID,
 			Enabled:     true,
-			TokenSource: deps.NewXBLTokenSource(ctx, subLive),
+			TokenSource: deps.NewXBLTokenSource(authCtx, subLive),
 		})
 	}
 

--- a/cmd/broadcaster/main_test.go
+++ b/cmd/broadcaster/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -130,6 +131,69 @@ func TestRunBroadcasterCommandStartsAndClosesBroadcaster(t *testing.T) {
 	}
 	if gotSubAccounts != 1 {
 		t.Fatalf("expected one sub-account, got %d", gotSubAccounts)
+	}
+}
+
+func TestRunBroadcasterCommandAppliesConfiguredHTTPProxy(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var gotClient *http.Client
+	var gotAuthClient *http.Client
+	err := runBroadcasterCommand(ctx, commandOptions{
+		ConfigPath: "/base/config.yml",
+	}, commandDeps{
+		Stdout: io.Discard,
+		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
+			cfg := broadcaster.DefaultConfigFile()
+			cfg.HTTP.Proxy = "http://127.0.0.1:8080"
+			cfg.Session.RemoteAddress = "127.0.0.1"
+			cfg.Session.RemotePort = "19132"
+			return cfg, nil
+		},
+		LoadLiveToken: func(string) (*oauth2.Token, error) {
+			return nil, errors.ErrUnsupported
+		},
+		NewLiveTokenSource: func(*oauth2.Token, io.Writer) oauth2.TokenSource {
+			return staticOAuthTokenSource{}
+		},
+		SaveLiveToken: func(string, *oauth2.Token) error {
+			return nil
+		},
+		NewXBLTokenSource: func(ctx context.Context, _ oauth2.TokenSource) xsapi.TokenSource {
+			gotAuthClient, _ = ctx.Value(oauth2.HTTPClient).(*http.Client)
+			return staticXBLTokenSource{}
+		},
+		NewBroadcaster: func(conf broadcaster.Config) (commandBroadcaster, error) {
+			gotClient = conf.HTTPClient
+			return fakeCommandBroadcaster{
+				start: func(context.Context) error {
+					cancel()
+					return nil
+				},
+				close: func() error {
+					return nil
+				},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotClient == nil {
+		t.Fatal("expected configured HTTP client")
+	}
+	if gotAuthClient != gotClient {
+		t.Fatal("expected Xbox auth context to use configured HTTP client")
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyURL, err := gotClient.Transport.(*http.Transport).Proxy(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("unexpected proxy URL %q", proxyURL.String())
 	}
 }
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,6 +1,9 @@
-configVersion: 2
+configVersion: 3
 debugMode: false
 suppressSessionUpdateMessage: false
+
+http:
+  proxy: ""
 
 session:
   remoteAddress: auto

--- a/config_file.go
+++ b/config_file.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -15,22 +16,28 @@ import (
 
 	"github.com/df-mc/go-xsapi"
 	"github.com/pelletier/go-toml/v2"
+	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/service"
 	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )
 
-const CurrentConfigVersion = 2
+const CurrentConfigVersion = 3
 
 type ConfigFile struct {
 	ConfigVersion                int                `yaml:"configVersion" toml:"configVersion"`
 	DebugMode                    bool               `yaml:"debugMode" toml:"debugMode"`
 	SuppressSessionUpdateMessage bool               `yaml:"suppressSessionUpdateMessage" toml:"suppressSessionUpdateMessage"`
+	HTTP                         HTTPFileConfig     `yaml:"http" toml:"http"`
 	Session                      SessionFileConfig  `yaml:"session" toml:"session"`
 	FriendSync                   FriendFileConfig   `yaml:"friendSync" toml:"friendSync"`
 	Notifications                NotificationConfig `yaml:"notifications" toml:"notifications"`
 	Gallery                      GalleryFileConfig  `yaml:"gallery" toml:"gallery"`
 	Accounts                     AccountsConfig     `yaml:"accounts" toml:"accounts"`
+}
+
+type HTTPFileConfig struct {
+	Proxy string `yaml:"proxy" toml:"proxy"`
 }
 
 type SessionFileConfig struct {
@@ -150,6 +157,46 @@ func DefaultConfigFile() ConfigFile {
 	}
 }
 
+func (h HTTPFileConfig) Client(base *http.Client) (*http.Client, error) {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	proxy := strings.TrimSpace(h.Proxy)
+	if proxy == "" {
+		return base, nil
+	}
+	proxyURL, err := url.Parse(proxy)
+	if err != nil {
+		return nil, fmt.Errorf("parse http proxy: %w", err)
+	}
+	if proxyURL.Scheme == "" || proxyURL.Host == "" {
+		return nil, fmt.Errorf("parse http proxy: proxy URL must include scheme and host")
+	}
+	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
+		return nil, fmt.Errorf("parse http proxy: unsupported scheme %q", proxyURL.Scheme)
+	}
+	transport, err := proxyTransport(base.Transport, proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	client := *base
+	client.Transport = transport
+	return &client, nil
+}
+
+func proxyTransport(base http.RoundTripper, proxyURL *url.URL) (http.RoundTripper, error) {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("configure http proxy: custom transport %T is not supported", base)
+	}
+	transport = transport.Clone()
+	transport.Proxy = http.ProxyURL(proxyURL)
+	return transport, nil
+}
+
 func LoadConfigFile(path string) (ConfigFile, error) {
 	cfg := DefaultConfigFile()
 	data, err := os.ReadFile(path)
@@ -226,6 +273,9 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 			WebQueryFallback: c.Session.WebQueryFallback,
 			QueryFallback:    c.Session.ConfigFallback,
 			WebQueryClient:   in.HTTPClient,
+		},
+		ListenConfig: minecraft.ListenConfig{
+			HTTPClient: in.HTTPClient,
 		},
 		UpdateInterval:               time.Duration(c.Session.UpdateInterval) * time.Second,
 		HTTPClient:                   in.HTTPClient,

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -1,6 +1,8 @@
 package broadcaster
 
 import (
+	"context"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -116,6 +118,45 @@ func TestConfigFileDisablesFriendSyncWhenNoActionsConfigured(t *testing.T) {
 	}
 	if runtime.FriendSync != nil {
 		t.Fatalf("expected friend sync disabled, got %#v", runtime.FriendSync)
+	}
+}
+
+func TestHTTPConfigClientConfiguresProxyTransport(t *testing.T) {
+	cfg := HTTPFileConfig{Proxy: "http://127.0.0.1:8080"}
+
+	client, err := cfg.Client(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyURL, err := client.Transport.(*http.Transport).Proxy(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if proxyURL.String() != "http://127.0.0.1:8080" {
+		t.Fatalf("unexpected proxy URL %q", proxyURL.String())
+	}
+}
+
+func TestHTTPConfigClientRejectsInvalidProxy(t *testing.T) {
+	cfg := HTTPFileConfig{Proxy: "://bad"}
+
+	if _, err := cfg.Client(nil); err == nil {
+		t.Fatal("expected invalid proxy error")
+	}
+}
+
+func TestHTTPConfigClientRejectsCustomTransportWithProxy(t *testing.T) {
+	cfg := HTTPFileConfig{Proxy: "http://127.0.0.1:8080"}
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, nil
+	})}
+
+	if _, err := cfg.Client(base); err == nil {
+		t.Fatal("expected custom transport error")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `http.proxy` config support and bump the example config version.
- Build a shared proxied `http.Client` for runtime HTTP paths and Xbox auth context wiring.
- Cover proxy client construction, invalid proxy handling, custom transport rejection, and CLI wiring tests.

## Validation
- `go test ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All outbound HTTP—including Microsoft/Xbox authentication—can be redirected when a proxy is configured; misconfiguration could break auth or API calls, though the change is opt-in with URL validation.
> 
> **Overview**
> Adds optional **`http.proxy`** configuration (config version **3**) so operators can route outbound traffic through an HTTP/HTTPS proxy.
> 
> When set, the app builds a shared **`http.Client`** with a cloned `*http.Transport` and wires it through runtime HTTP usage (session queries, gallery, notifications, Minecraft listen config) and Xbox auth by attaching the same client to **`oauth2.HTTPClient`** for primary and sub-account token sources.
> 
> Invalid or unsupported proxy URLs and non-`*http.Transport` base transports fail at startup; tests cover proxy application, validation, and CLI wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bea9186d9f2b9f3e816858fd6f2ab6458935dc05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring an HTTP proxy URL in the configuration file to route HTTP traffic through a proxy.

* **Documentation**
  * Updated configuration documentation to include the new HTTP proxy setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HashimTheArab/go-mcxboxbroadcast/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->