### PR TITLE
Fix Minecraft friend-list session metadata

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -217,7 +217,7 @@ func (b *Broadcaster) friendSyncer() FriendSyncer {
 
 func (b *Broadcaster) roomStatusProvider(status room.Status) room.StatusProvider {
 	if b.conf.StatusProvider != nil {
-		return normalizedStatusProvider{Provider: b.conf.StatusProvider}
+		return normalizedStatusProvider{Provider: b.conf.StatusProvider, OwnerID: b.primaryXUID()}
 	}
 	return room.NewStatusProvider(status)
 }
@@ -232,7 +232,7 @@ func (b *Broadcaster) roomListenConfig(status room.Status) room.ListenConfig {
 
 func (b *Broadcaster) minecraftStatusProvider(status room.Status) minecraft.ServerStatusProvider {
 	if b.conf.StatusProvider != nil {
-		return roomMinecraftStatusProvider{Provider: normalizedStatusProvider{Provider: b.conf.StatusProvider}}
+		return roomMinecraftStatusProvider{Provider: b.conf.StatusProvider}
 	}
 	return minecraft.NewStatusProvider(status.WorldName, status.HostName)
 }
@@ -297,7 +297,10 @@ func (b *Broadcaster) primaryXUID() string {
 	if b.conf.XUID != "" {
 		return b.conf.XUID
 	}
-	return clientXUID(b.conf.XBLClient)
+	if xuid := clientXUID(b.conf.XBLClient); xuid != "" {
+		return xuid
+	}
+	return clientXUID(b.xblClient)
 }
 
 func accountXUID(account SubAccountConfig) string {

--- a/constants.go
+++ b/constants.go
@@ -6,6 +6,8 @@ const (
 	ServiceConfigID = "4fc10100-5f7a-4470-899b-280835760c07"
 	TemplateName    = "MinecraftLobby"
 	TitleID         = 896928775
+
+	xboxLiveRelyingParty = "http://xboxlive.com"
 )
 
 var serviceConfigUUID = uuid.MustParse(ServiceConfigID)

--- a/integration_clients_test.go
+++ b/integration_clients_test.go
@@ -313,8 +313,9 @@ func TestStatusUsesConfiguredProvider(t *testing.T) {
 	b, err := New(Config{
 		XBLTokenSource:  staticTokenSource{},
 		LiveTokenSource: staticOAuthSource{},
+		XUID:            "123",
 		Server:          ServerInfo{Host: "127.0.0.1", Port: 19132},
-		StatusProvider:  staticStatusProvider{host: "Provider Host", world: "Provider World"},
+		StatusProvider:  staticStatusProvider{host: "Provider Host", world: "Provider World", titleID: TitleID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -326,15 +327,31 @@ func TestStatusUsesConfiguredProvider(t *testing.T) {
 	if status.HostName != "Provider Host" || status.WorldName != "Provider World" {
 		t.Fatalf("provider not used: %#v", status)
 	}
+	if status.OwnerID != "123" {
+		t.Fatalf("provider owner id = %q", status.OwnerID)
+	}
+	if status.TitleID != 0 {
+		t.Fatalf("provider title id = %d", status.TitleID)
+	}
 }
 
 func TestRoomStatusProviderNormalizesConfiguredProvider(t *testing.T) {
 	b := &Broadcaster{conf: Config{
-		StatusProvider: staticStatusProvider{host: "Provider Host", world: "Provider World"},
+		XUID:           "123",
+		StatusProvider: staticStatusProvider{host: "Provider Host", world: "Provider World", titleID: TitleID},
 	}}
 	status := b.roomStatusProvider(room.Status{}).RoomStatus()
-	if status.Protocol == 0 || status.Version == "" || status.TitleID == 0 {
+	if status.Protocol == 0 || status.Version == "" {
 		t.Fatalf("provider status was not normalized: %#v", status)
+	}
+	if status.OwnerID != "123" {
+		t.Fatalf("provider owner id = %q", status.OwnerID)
+	}
+	if status.TransportLayer != room.TransportLayerNetherNet {
+		t.Fatalf("provider transport layer = %d", status.TransportLayer)
+	}
+	if status.TitleID != 0 {
+		t.Fatalf("provider title id = %d", status.TitleID)
 	}
 	if status.BroadcastSetting == 0 || status.Joinability == "" {
 		t.Fatalf("provider session controls were not normalized: %#v", status)
@@ -403,6 +420,7 @@ func TestStartAdvertisesJSONRPCConnectionWhenConfigured(t *testing.T) {
 	b := &Broadcaster{
 		conf: Config{
 			Server:               ServerInfo{Host: "127.0.0.1", Port: 19132},
+			XBLTokenSource:       staticTokenSource{xuid: "123"},
 			Signaling:            sig,
 			SignalingMode:        SignalingModeJSONRPC,
 			MinecraftTokenSource: minecraftTokenSourceWithPMID{pmid: pmsgID},
@@ -431,6 +449,15 @@ func TestStartAdvertisesJSONRPCConnectionWhenConfigured(t *testing.T) {
 	}
 	if got.PmsgID != pmsgID {
 		t.Fatalf("pmsg id = %s", got.PmsgID)
+	}
+	if announcer.status.OwnerID != "123" {
+		t.Fatalf("owner id = %q", announcer.status.OwnerID)
+	}
+	if announcer.status.TransportLayer != room.TransportLayerNetherNet {
+		t.Fatalf("transport layer = %d", announcer.status.TransportLayer)
+	}
+	if announcer.status.TitleID != 0 {
+		t.Fatalf("title id = %d", announcer.status.TitleID)
 	}
 }
 
@@ -490,6 +517,7 @@ func TestQueryStatusFallsBackToWeb(t *testing.T) {
 
 type staticStatusProvider struct {
 	host, world string
+	titleID     int64
 }
 
 func (s staticStatusProvider) RoomStatus() room.Status {
@@ -498,6 +526,7 @@ func (s staticStatusProvider) RoomStatus() room.Status {
 		WorldName:      s.world,
 		MemberCount:    1,
 		MaxMemberCount: 2,
+		TitleID:        s.titleID,
 	}
 }
 

--- a/status.go
+++ b/status.go
@@ -20,8 +20,12 @@ import (
 var defaultRoomStatus = room.DefaultStatus()
 
 func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
+	ownerID, err := b.primaryXUIDForStatus(ctx)
+	if err != nil {
+		return room.Status{}, err
+	}
 	if b.conf.StatusProvider != nil {
-		return normalizeStatus(b.conf.StatusProvider.RoomStatus()), nil
+		return normalizeStatusWithOwner(b.conf.StatusProvider.RoomStatus(), ownerID), nil
 	}
 	st := b.conf.Status
 	if st.QueryTarget {
@@ -43,6 +47,7 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 	return normalizeStatus(room.Status{
 		HostName:                stripColour(defaultString(st.HostName, "MCXboxBroadcast")),
 		WorldName:               stripColour(defaultString(st.WorldName, defaultString(st.HostName, "MCXboxBroadcast"))),
+		OwnerID:                 ownerID,
 		WorldType:               defaultString(st.WorldType, room.WorldTypeCreative),
 		MemberCount:             max(st.Players, 1),
 		MaxMemberCount:          max(st.MaxPlayers, max(st.Players, 1)+1),
@@ -50,12 +55,42 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 		Joinability:             defaultString(st.Joinability, room.JoinabilityJoinableByFriends),
 		Protocol:                protocol.CurrentProtocol,
 		Version:                 protocol.CurrentVersion,
-		TitleID:                 TitleID,
+		TransportLayer:          room.TransportLayerNetherNet,
 		LanGame:                 false,
 		OnlineCrossPlatformGame: true,
 		CrossPlayDisabled:       false,
 		LevelID:                 levelID(st.LevelID),
 	}), nil
+}
+
+func (b *Broadcaster) primaryXUIDForStatus(ctx context.Context) (string, error) {
+	if xuid := b.primaryXUID(); xuid != "" {
+		return xuid, nil
+	}
+	if b.conf.XBLTokenSource == nil {
+		return "", nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	token, err := b.conf.XBLTokenSource.XSTSToken(ctx, xboxLiveRelyingParty)
+	if err != nil {
+		return "", fmt.Errorf("resolve xbox live xuid: %w", err)
+	}
+	if token == nil {
+		return "", fmt.Errorf("resolve xbox live xuid: token source returned nil XSTS token")
+	}
+	xuid := token.UserInfo().XUID
+	b.conf.XUID = xuid
+	return xuid, nil
+}
+
+func normalizeStatusWithOwner(status room.Status, ownerID string) room.Status {
+	status = normalizeStatus(status)
+	if status.OwnerID == "" {
+		status.OwnerID = ownerID
+	}
+	return status
 }
 
 func normalizeStatus(status room.Status) room.Status {
@@ -89,9 +124,10 @@ func normalizeStatus(status room.Status) room.Status {
 	if status.Version == "" {
 		status.Version = protocol.CurrentVersion
 	}
-	if status.TitleID == 0 {
-		status.TitleID = TitleID
-	}
+	// Minecraft friend-list sessions use TitleId=0 in MPSD custom properties.
+	// The package TitleID constant is still used for Xbox invite handles.
+	status.TitleID = 0
+	status.TransportLayer = room.TransportLayerNetherNet
 	status.OnlineCrossPlatformGame = true
 	if status.LevelID == "" {
 		status.LevelID = defaults.LevelID
@@ -101,13 +137,14 @@ func normalizeStatus(status room.Status) room.Status {
 
 type normalizedStatusProvider struct {
 	Provider room.StatusProvider
+	OwnerID  string
 }
 
 func (p normalizedStatusProvider) RoomStatus() room.Status {
 	if p.Provider == nil {
-		return normalizeStatus(room.Status{})
+		return normalizeStatusWithOwner(room.Status{}, p.OwnerID)
 	}
-	return normalizeStatus(p.Provider.RoomStatus())
+	return normalizeStatusWithOwner(p.Provider.RoomStatus(), p.OwnerID)
 }
 
 type roomMinecraftStatusProvider struct {

--- a/status_test.go
+++ b/status_test.go
@@ -11,6 +11,7 @@ func TestStatusDefaults(t *testing.T) {
 	b, err := New(Config{
 		XBLTokenSource:  staticTokenSource{},
 		LiveTokenSource: staticOAuthSource{},
+		XUID:            "123",
 		Server:          ServerInfo{Host: "127.0.0.1", Port: 19132},
 		Status: Status{
 			HostName:   "§aHost",
@@ -37,6 +38,15 @@ func TestStatusDefaults(t *testing.T) {
 	}
 	if status.MaxMemberCount != 2 {
 		t.Fatalf("unexpected max member count %d", status.MaxMemberCount)
+	}
+	if status.OwnerID != "123" {
+		t.Fatalf("unexpected owner id %q", status.OwnerID)
+	}
+	if status.TransportLayer != room.TransportLayerNetherNet {
+		t.Fatalf("unexpected transport layer %d", status.TransportLayer)
+	}
+	if status.TitleID != 0 {
+		t.Fatalf("unexpected title id %d", status.TitleID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- publish MPSD room status with Minecraft-compatible friend-list metadata: ownerId, NetherNet transport, and TitleId=0
- resolve ownerId from the Xbox token source when XUID is not configured, without constructing an xsapi client/RTA connection just for status metadata
- keep custom status providers normalized for MPSD while avoiding double normalization on the Minecraft ping status path

## Why
A reported friend bot visibility issue can happen before friend sync or transfer logic if the published MPSD custom properties do not match the host-side Minecraft session shape. This aligns the Go broadcaster with NetherNet-hosted friend-list sessions instead of publishing stale package-title/RakNet-style metadata.

## Validation
- go test -count=1 ./...
- go vet ./...
- staticcheck ./...
- git diff --check
- code-reviewer subagent follow-up: no remaining findings

## Not tested
- live Xbox/Minecraft friend-list visibility with real credentials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Xbox session custom properties and status resolution at startup/update; mis-set owner or title metadata could affect friend-list visibility, though scope is limited to status normalization and token lookup.
> 
> **Overview**
> Published MPSD room status now matches **Minecraft friend-list sessions**: **`ownerId`**, **NetherNet** transport, and **`TitleId=0`** in custom properties (the package **`TitleID`** constant remains for Xbox invite handles elsewhere).
> 
> **Owner resolution** fills **`OwnerID`** from configured **`XUID`**, existing Xbox clients, or—when neither is set—a lightweight **`XSTSToken`** lookup via **`xboxLiveRelyingParty`**, without spinning up an xsapi client/RTA just for metadata. **`primaryXUID()`** also considers the lazily created **`xblClient`**.
> 
> **Status plumbing** uses **`normalizeStatusWithOwner`** for announce/listen paths; **`roomMinecraftStatusProvider`** wraps the raw provider so Minecraft ping status is not double-normalized. Tests assert owner, transport, and title id on announce and provider paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa6445e752303a422f3775ea593ca79eea961f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->