### PR TITLE
Fix code review findings: Java parity, friend sync resilience, session self-healing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,16 @@ FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
+RUN addgroup -S app && adduser -S -G app -h /opt/app app
+
 WORKDIR /opt/app/config
 
 COPY --from=build /app/mcxboxbroadcast_bin /mcxboxbroadcast
 
 VOLUME ["/opt/app/config"]
+
+RUN chown -R app:app /opt/app
+
+USER app:app
 
 CMD ["/mcxboxbroadcast", "-config", "/opt/app/config/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,11 @@ WORKDIR /opt/app/config
 
 COPY --from=build /app/mcxboxbroadcast_bin /mcxboxbroadcast
 
-VOLUME ["/opt/app/config"]
-
+# chown must precede VOLUME: build steps that modify a path after it is
+# declared a volume are discarded, leaving the mount root-owned at runtime.
 RUN chown -R app:app /opt/app
+
+VOLUME ["/opt/app/config"]
 
 USER app:app
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# broadcaster-go
+# go-mcxboxbroadcast
 
-`broadcaster-go` publishes a Minecraft: Bedrock Edition server as an Xbox Live
+`go-mcxboxbroadcast` publishes a Minecraft: Bedrock Edition server as an Xbox Live
 friend-list world and transfers clients that join the published NetherNet
 session to the configured Bedrock server.
 
@@ -8,12 +8,15 @@ The library is modelled after
 [MCXboxBroadcast](https://github.com/rtm516/MCXboxBroadcast) while using
 Go-first building blocks:
 
-- `github.com/df-mc/go-xsapi/v2` for Xbox Live MPSD/RTA session publishing.
+- `github.com/df-mc/go-xsapi/v2` for Xbox Live MPSD/RTA session publishing,
+  replaced in `go.mod` with the `HashimTheArab/go-xsapi` fork.
 - `github.com/df-mc/go-nethernet` for NetherNet/WebRTC listener support.
 - `hashimthearab/gophertunnel` Lunar P2P branch for NetherNet, signaling,
   room announcements, and `minecraft/p2p`-compatible session metadata. This
   should be updated to the official `sandertv/gophertunnel` once it supports
   Xbox friend-list NetherNet signaling.
+- `sandertv/go-raknet`, replaced in `go.mod` with the `hashimthearab/go-raknet`
+  fork for RakNet ping compatibility.
 
 ## Acknowledgements
 
@@ -40,10 +43,13 @@ counts for each sync pass.
 
 The config exposes the same operator-facing areas as MCXboxBroadcast:
 
-- session target, remote address/port auto behavior, update interval, query
-  options, broadcast setting, joinability, world type, and displayed MOTD data
+- session target, update interval, query options, broadcast setting,
+  joinability, world type, and displayed MOTD data
 - gallery showcase image upload through `gallery.imagePath`
 - friend sync automation and expiry settings, including last-seen history path
+  (stored as JSON at `friendSync.expiry.historyPath`, not Java's SQLite
+  database — operators migrating from MCXboxBroadcast start with a fresh
+  expiry history)
 - Slack/Discord-compatible webhook notifications
 - primary and sub-account token cache paths
 - optional HTTP proxy URL through `http.proxy`
@@ -83,8 +89,7 @@ if err != nil {
 b, err := broadcaster.New(broadcaster.Config{
     XBLClient:           xblClient,
     XBLTokenSource:      xblSource,
-    XUID:                xblClient.UserInfo().XUID,
-    LiveTokenSource:     live,
+    XUID:                 xblClient.UserInfo().XUID,
     MinecraftTokenSource: minecraftTokens,
     Server: broadcaster.ServerInfo{
         Host: "play.example.net",

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -251,6 +251,20 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	return nil
 }
 
+// subAccountFriendSyncActive reports whether any enabled sub-account runs a
+// friend syncer sharing the primary's history store.
+func (b *Broadcaster) subAccountFriendSyncActive() bool {
+	for _, account := range b.conf.SubAccounts {
+		if !account.Enabled || !subAccountHasXBLCredentials(account) {
+			continue
+		}
+		if account.FriendSync != nil || b.conf.FriendSync != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // startSubAccountFriendSync runs a friend syncer per enabled sub-account so
 // people who friend a sub-account are followed back. Sub-accounts without an
 // explicit FriendSync configuration inherit the primary account's.
@@ -327,8 +341,11 @@ func (b *Broadcaster) friendSyncer() FriendSyncer {
 		Config:   *b.conf.FriendSync,
 		History:  b.conf.FriendHistory,
 		Notifier: b.conf.Notifier,
-		// Only the primary account prunes the shared history store.
-		PruneHistory: true,
+		// Pruning compares the store against the primary's friend list only,
+		// so it must stay off while sub-account syncers share the store:
+		// people who only friended a sub-account would be pruned and re-seeded
+		// with a fresh expiry clock every pass.
+		PruneHistory: !b.subAccountFriendSyncActive(),
 		Log:          b.log,
 	}
 	if b.conf.FriendSync.InitialInvite {
@@ -809,6 +826,11 @@ func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
 			continue
 		}
 		if err := b.startSubAccount(ctx, account); err != nil {
+			// A canceled context means the broadcaster is shutting down, not
+			// that this or the remaining sub-accounts genuinely failed.
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			b.log.Error("start sub-account; continuing without it", "sub_account", account.ID, "err", err)
 			b.notify(ctx, "Sub-account "+account.ID+" failed to start: "+err.Error())
 		}

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -60,7 +60,14 @@ type Broadcaster struct {
 	started  bool
 	acceptWg sync.WaitGroup
 
+	// lastQuery is the most recent successful target-server query, kept so
+	// query failures fall back to real data instead of failing the update.
+	lastQuery *minecraft.ServerStatus
+
 	transferCloseTimeout time.Duration
+	// subAccountSettleDelay is the wait after establishing a new sub-account
+	// friendship before joining the session.
+	subAccountSettleDelay time.Duration
 }
 
 type transferConn interface {
@@ -107,7 +114,12 @@ func New(conf Config) (*Broadcaster, error) {
 	if conf.UpdateInterval < 20*time.Second {
 		conf.UpdateInterval = 20 * time.Second
 	}
-	return &Broadcaster{conf: conf, log: conf.Log.With("src", "broadcaster")}, nil
+	return &Broadcaster{
+		conf:                  conf,
+		log:                   conf.Log.With("src", "broadcaster"),
+		transferCloseTimeout:  conf.TransferCloseTimeout,
+		subAccountSettleDelay: 5 * time.Second,
+	}, nil
 }
 
 // Start publishes the Xbox session and starts accepting NetherNet clients.
@@ -164,6 +176,12 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	if connection != nil {
 		b.announcer = signalingConnectionAnnouncer{Announcer: b.announcer, connection: *connection}
 		b.debug("using jsonrpc signaling", "nethernet_id", connection.NetherNetID, "pmsg_id", connection.PmsgID)
+	} else if len(status.SupportedConnections) == 0 {
+		// Without a signaling connection or caller-provided connections the
+		// session would publish SupportedConnections: null and be unjoinable.
+		b.cancel()
+		err := errors.New("session would publish no supported connections and be unjoinable; use jsonrpc signaling or provide SupportedConnections via a status provider")
+		return errors.Join(err, b.cleanupStartupFailure(true))
 	}
 	b.info("creating xbox live session")
 	if err := b.announcer.Announce(b.ctx, status); err != nil {
@@ -228,7 +246,53 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 		)
 		go b.friendSyncer().Run(b.ctx)
 	}
+	b.startSubAccountFriendSync()
+	go b.logSocialSummary()
 	return nil
+}
+
+// startSubAccountFriendSync runs a friend syncer per enabled sub-account so
+// people who friend a sub-account are followed back. Sub-accounts without an
+// explicit FriendSync configuration inherit the primary account's.
+func (b *Broadcaster) startSubAccountFriendSync() {
+	for _, account := range b.conf.SubAccounts {
+		if !account.Enabled || account.XBLClient == nil {
+			continue
+		}
+		conf := account.FriendSync
+		if conf == nil {
+			conf = b.conf.FriendSync
+		}
+		if conf == nil {
+			continue
+		}
+		syncer := FriendSyncer{
+			Client:   b.friendClientFor(account.XBLClient),
+			Config:   *conf,
+			History:  b.conf.FriendHistory,
+			Notifier: b.conf.Notifier,
+			Log:      b.log.With("sub_account", account.ID),
+		}
+		b.debug("starting sub-account friend sync", "sub_account", account.ID)
+		go syncer.Run(b.ctx)
+	}
+}
+
+// logSocialSummary logs the authenticated account and its friend usage at
+// startup, mirroring MCXboxBroadcast's "N/2000 friends" line.
+func (b *Broadcaster) logSocialSummary() {
+	ctx, cancel := context.WithTimeout(b.ctx, 15*time.Second)
+	defer cancel()
+	summary, err := b.friendClientFor(b.conf.XBLClient).Summary(ctx)
+	if err != nil {
+		b.debug("fetch social summary", "err", err)
+		return
+	}
+	b.info("authenticated to xbox live",
+		"gamertag", b.hostNameFallback(),
+		"xuid", b.primaryXUID(),
+		"friends", fmt.Sprintf("%d/2000", summary.TargetFollowingCount),
+	)
 }
 
 // presenceClients builds the list of Xbox presence clients for heartbeat updates.
@@ -259,10 +323,13 @@ func (b *Broadcaster) presenceClients() []PresenceClient {
 // friendSyncer creates a FriendSyncer from the broadcaster's current config.
 func (b *Broadcaster) friendSyncer() FriendSyncer {
 	syncer := FriendSyncer{
-		Client:  b.friendClientFor(b.conf.XBLClient),
-		Config:  *b.conf.FriendSync,
-		History: b.conf.FriendHistory,
-		Log:     b.log,
+		Client:   b.friendClientFor(b.conf.XBLClient),
+		Config:   *b.conf.FriendSync,
+		History:  b.conf.FriendHistory,
+		Notifier: b.conf.Notifier,
+		// Only the primary account prunes the shared history store.
+		PruneHistory: true,
+		Log:          b.log,
 	}
 	if b.conf.FriendSync.InitialInvite {
 		syncer.Inviter = &broadcasterInviter{b: b}
@@ -289,11 +356,13 @@ func (b *Broadcaster) roomListenConfig(status room.Status) room.ListenConfig {
 }
 
 // minecraftListenConfig applies broadcaster defaults to a Minecraft listener.
+// Client authentication follows ListenConfig.AuthenticationDisabled: chains
+// are validated by default like MCXboxBroadcast, so player history only
+// records verified XUIDs.
 func (b *Broadcaster) minecraftListenConfig(status room.Status) minecraft.ListenConfig {
 	conf := b.conf.ListenConfig
 	conf.ErrorLog = b.log
 	conf.StatusProvider = b.minecraftStatusProvider(status)
-	conf.AuthenticationDisabled = true
 	conf.CompressionThreshold = -1
 	conf.ForceDisableVibrantVisuals = true
 	conf.ResourcePackWorldTemplateUUID = uuid.New()
@@ -720,7 +789,9 @@ func (b *Broadcaster) newAnnouncer(ctx context.Context) (room.Announcer, error) 
 	}, b.primaryXUID(), b.log), nil
 }
 
-// startSubAccounts publishes MPSD sessions for all enabled sub-accounts.
+// startSubAccounts joins the primary session with all enabled sub-accounts.
+// A failing sub-account is logged and skipped so it cannot take down the
+// broadcaster, matching MCXboxBroadcast.
 func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
 	for i := range b.conf.SubAccounts {
 		account := &b.conf.SubAccounts[i]
@@ -737,38 +808,48 @@ func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
 			b.log.Warn("sub-account skipped because xbox live credentials are missing", "sub_account", account.ID)
 			continue
 		}
-		if _, err := b.subAccountXBLClient(ctx, account); err != nil {
-			return fmt.Errorf("prepare sub-account %q xbox live client: %w", account.ID, err)
+		if err := b.startSubAccount(ctx, account); err != nil {
+			b.log.Error("start sub-account; continuing without it", "sub_account", account.ID, "err", err)
+			b.notify(ctx, "Sub-account "+account.ID+" failed to start: "+err.Error())
 		}
-		if account.XUID == "" {
-			account.XUID = accountXUID(*account)
-		}
-		if account.XUID == "" {
-			b.log.Warn("sub-account xuid unavailable", "sub_account", account.ID)
-		}
-		if err := b.ensureSubAccountMutualFollow(ctx, *account); err != nil {
-			return fmt.Errorf("prepare sub-account %q mutual follow: %w", account.ID, err)
-		}
-		pub := account.PublishConfig
-		b.debug("publishing sub-account session",
-			"sub_account", account.ID,
-			"xuid", account.XUID,
-			"session_name", b.sessionRef.Name,
-			"join_restriction", defaultString(pub.JoinRestriction, mpsd.SessionRestrictionFollowed),
-			"read_restriction", defaultString(pub.ReadRestriction, mpsd.SessionRestrictionFollowed),
-		)
-		s, err := b.publishSubAccount(ctx, *account, pub)
-		if err != nil {
-			return fmt.Errorf("start sub-account %q: %w", account.ID, err)
-		}
-		b.subSessions = append(b.subSessions, s)
-		b.debug("published sub-account session", "sub_account", account.ID, "xuid", account.XUID)
 	}
 	return nil
 }
 
-// publishSubAccount publishes a single sub-account's MPSD session.
-func (b *Broadcaster) publishSubAccount(ctx context.Context, account SubAccountConfig, pub mpsd.PublishConfig) (*mpsd.Session, error) {
+// startSubAccount prepares one sub-account and joins it to the primary session.
+func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountConfig) error {
+	if _, err := b.subAccountXBLClient(ctx, account); err != nil {
+		return fmt.Errorf("prepare xbox live client: %w", err)
+	}
+	if account.XUID == "" {
+		account.XUID = accountXUID(*account)
+	}
+	if account.XUID == "" {
+		b.log.Warn("sub-account xuid unavailable", "sub_account", account.ID)
+	}
+	if err := b.ensureSubAccountMutualFollow(ctx, *account); err != nil {
+		return fmt.Errorf("prepare mutual follow: %w", err)
+	}
+	pub := account.PublishConfig
+	b.debug("joining sub-account to session",
+		"sub_account", account.ID,
+		"xuid", account.XUID,
+		"session_name", b.sessionRef.Name,
+	)
+	s, err := b.joinSubAccount(ctx, *account, pub)
+	if err != nil {
+		return fmt.Errorf("join session: %w", err)
+	}
+	b.subSessions = append(b.subSessions, s)
+	b.debug("joined sub-account to session", "sub_account", account.ID, "xuid", account.XUID)
+	return nil
+}
+
+// joinSubAccount joins a sub-account to the primary session through the
+// primary account's activity handle. Publishing the same session reference
+// again would fail with 412 Precondition Failed, so the sub-account looks up
+// the handle and joins it like MCXboxBroadcast's sub-sessions.
+func (b *Broadcaster) joinSubAccount(ctx context.Context, account SubAccountConfig, pub mpsd.PublishConfig) (*mpsd.Session, error) {
 	if b.subAccountPublisher != nil {
 		return b.subAccountPublisher(ctx, account, b.sessionRef, pub)
 	}
@@ -779,10 +860,35 @@ func (b *Broadcaster) publishSubAccount(ctx context.Context, account SubAccountC
 	if client == nil {
 		return nil, errors.New("sub-account MPSD client is nil")
 	}
-	return client.Publish(ctx, b.sessionRef, pub)
+	handleID, err := b.primaryActivityHandleID(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	return client.Join(ctx, handleID, mpsd.JoinConfig{})
 }
 
-// ensureSubAccountMutualFollow makes the primary and sub-account follow each other.
+// primaryActivityHandleID finds the primary account's activity handle for the
+// published session.
+func (b *Broadcaster) primaryActivityHandleID(ctx context.Context, client *mpsd.Client) (uuid.UUID, error) {
+	primaryXUID := b.primaryXUID()
+	if primaryXUID == "" {
+		return uuid.Nil, errors.New("primary xuid unavailable for activity handle lookup")
+	}
+	handles, err := client.ActivitiesForUsers(ctx, b.sessionRef.ServiceConfigID, []string{primaryXUID})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("query primary activity handles: %w", err)
+	}
+	for _, handle := range handles {
+		if handle.SessionReference.Name == b.sessionRef.Name {
+			return handle.ID, nil
+		}
+	}
+	return uuid.Nil, fmt.Errorf("no activity handle found for session %q", b.sessionRef.Name)
+}
+
+// ensureSubAccountMutualFollow makes the primary and sub-account follow each
+// other, skipping follows that already exist so restarts do not re-PUT both
+// directions.
 func (b *Broadcaster) ensureSubAccountMutualFollow(ctx context.Context, account SubAccountConfig) error {
 	primaryXUID := b.primaryXUID()
 	subXUID := accountXUID(account)
@@ -790,14 +896,47 @@ func (b *Broadcaster) ensureSubAccountMutualFollow(ctx context.Context, account 
 		return nil
 	}
 	primary := b.friendClientFor(b.conf.XBLClient)
-	if err := primary.Follow(ctx, subXUID); err != nil {
-		return fmt.Errorf("primary follow sub-account: %w", err)
-	}
 	sub := b.friendClientFor(account.XBLClient)
-	if err := sub.Follow(ctx, primaryXUID); err != nil {
-		return fmt.Errorf("sub-account follow primary: %w", err)
+	primaryFollowsSub, subFollowsPrimary := subAccountFollowState(ctx, sub, primaryXUID)
+	followed := false
+	if !primaryFollowsSub {
+		if err := primary.Follow(ctx, subXUID); err != nil {
+			return fmt.Errorf("primary follow sub-account: %w", err)
+		}
+		followed = true
+	}
+	if !subFollowsPrimary {
+		if err := sub.Follow(ctx, primaryXUID); err != nil {
+			return fmt.Errorf("sub-account follow primary: %w", err)
+		}
+		followed = true
+	}
+	if followed && b.subAccountSettleDelay > 0 {
+		// Give the friendship a moment to settle before the session join,
+		// like MCXboxBroadcast's sub-session startup.
+		select {
+		case <-time.After(b.subAccountSettleDelay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 	return nil
+}
+
+// subAccountFollowState reports whether the primary and sub-account already
+// follow each other, from the sub-account's view of the primary profile.
+// Lookup failures return false so the follows are attempted anyway.
+func subAccountFollowState(ctx context.Context, sub FriendClient, primaryXUID string) (primaryFollowsSub, subFollowsPrimary bool) {
+	people, err := sub.Friends(ctx)
+	if err != nil {
+		return false, false
+	}
+	for _, p := range people {
+		if p.XUID == primaryXUID {
+			return p.IsFollowingCaller, p.IsFollowedByCaller
+		}
+	}
+	return false, false
 }
 
 // uploadGallery uploads the configured showcase image to the Xbox gallery.
@@ -1026,11 +1165,8 @@ func (b *Broadcaster) notify(ctx context.Context, message string) {
 	}
 }
 
-// notifySessionUpdateFailure notifies about a session update failure unless suppressed.
+// notifySessionUpdateFailure notifies about a session update failure.
 func (b *Broadcaster) notifySessionUpdateFailure(ctx context.Context, err error) {
-	if b.conf.SuppressSessionUpdateMessage {
-		return
-	}
 	b.notify(ctx, "Xbox session update failed: "+err.Error())
 }
 
@@ -1214,25 +1350,115 @@ func (b *Broadcaster) startGameBeforeTransfer() *packet.StartGame {
 	}
 }
 
-// updateLoop periodically refreshes the Xbox session metadata.
+const (
+	// sessionMemberRestartThreshold mirrors Java's restart at 28/30 members;
+	// a full member list permanently blocks new joiners.
+	sessionMemberRestartThreshold = 28
+	// sessionUpdateFailureLimit is how many consecutive update failures
+	// trigger a full session recreation.
+	sessionUpdateFailureLimit = 3
+)
+
+// updateLoop periodically refreshes the Xbox session metadata, checking
+// session health before each update like Java's checkConnection().
 func (b *Broadcaster) updateLoop() {
 	ticker := time.NewTicker(b.conf.UpdateInterval)
 	defer ticker.Stop()
+	consecutiveFailures := 0
 	for {
 		select {
 		case <-ticker.C:
+			if b.checkSessionHealth() {
+				consecutiveFailures = 0
+				continue
+			}
 			ctx, cancel := context.WithTimeout(b.ctx, 15*time.Second)
 			if err := b.Update(ctx); err == nil {
+				consecutiveFailures = 0
 				b.debug("updated xbox live session")
 			} else if !errors.Is(err, context.Canceled) {
+				consecutiveFailures++
 				b.log.Error("update session", "err", err)
 				b.notifySessionUpdateFailure(ctx, err)
+				if consecutiveFailures >= sessionUpdateFailureLimit {
+					consecutiveFailures = 0
+					b.recreateAfterFailure("repeated session update failures")
+				}
 			}
 			cancel()
 		case <-b.ctx.Done():
 			return
 		}
 	}
+}
+
+// checkSessionHealth recreates the session when it is dead or nearly full and
+// reports whether a recreation was attempted.
+func (b *Broadcaster) checkSessionHealth() bool {
+	reason := b.sessionUnhealthyReason()
+	if reason == "" {
+		return false
+	}
+	b.recreateAfterFailure(reason)
+	return true
+}
+
+// sessionUnhealthyReason reports why the published session needs recreation,
+// or an empty string when it is healthy.
+func (b *Broadcaster) sessionUnhealthyReason() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	announcer, ok := xblAnnouncer(b.announcer)
+	if !ok {
+		return ""
+	}
+	announcer.Lock()
+	session := announcer.Session
+	announcer.Unlock()
+	if session == nil {
+		return ""
+	}
+	if session.Context().Err() != nil {
+		return "mpsd session lost"
+	}
+	if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
+		return fmt.Sprintf("session has %d/30 members", count)
+	}
+	for _, s := range b.subSessions {
+		if s.Context().Err() != nil {
+			return "sub-account session lost"
+		}
+	}
+	return ""
+}
+
+// sessionMemberCount counts the members of an MPSD session.
+func sessionMemberCount(session *mpsd.Session) int {
+	count := 0
+	for range session.Members() {
+		count++
+	}
+	return count
+}
+
+// recreateAfterFailure rebuilds the whole session stack after a health-check
+// failure. Failures are logged and retried on the next tick rather than
+// shutting the broadcaster down.
+func (b *Broadcaster) recreateAfterFailure(reason string) {
+	if b.ctx.Err() != nil {
+		return
+	}
+	if !b.canRecreateSignaling() {
+		b.warn("session is unhealthy but signaling is statically configured; cannot re-create", "reason", reason)
+		return
+	}
+	b.warn("re-creating xbox live session", "reason", reason)
+	if err := b.recreateSession(); err != nil {
+		b.log.Error("re-create session failed", "reason", reason, "err", err)
+		b.notify(b.ctx, "Xbox session recreation failed: "+err.Error())
+		return
+	}
+	b.info("xbox live session re-created", "reason", reason)
 }
 
 // canRecreateSignaling reports whether signaling can be rebuilt (not statically configured).
@@ -1253,6 +1479,15 @@ func (b *Broadcaster) watchSignaling() {
 	select {
 	case <-sig.Context().Done():
 		if b.ctx.Err() != nil {
+			return
+		}
+		b.mu.Lock()
+		current := b.signaling
+		b.mu.Unlock()
+		if current != nil && current != sig {
+			// The session was already re-created (for example by the health
+			// check); watch the replacement signaling instead.
+			go b.watchSignaling()
 			return
 		}
 		b.warn("connection to signaling lost, re-creating session...",
@@ -1367,6 +1602,9 @@ func (b *Broadcaster) recreateSession() error {
 		defer b.acceptWg.Done()
 		b.acceptListener(l)
 	}()
+	// Re-showcase the gallery image so a swapped file does not require a
+	// process restart; the upload no-ops when the image is already set.
+	go b.uploadGalleryWithTimeout()
 	return nil
 }
 
@@ -1385,7 +1623,13 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 	if err := b.announcer.Announce(ctx, status); err != nil {
 		return err
 	}
-	b.info("updated session")
+	// Matching MCXboxBroadcast, suppressSessionUpdateMessage only demotes the
+	// periodic success log to debug level.
+	if b.conf.SuppressSessionUpdateMessage {
+		b.debug("updated session")
+	} else {
+		b.info("updated session")
+	}
 	return nil
 }
 

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -51,12 +51,83 @@ func TestBroadcasterStartSubAccountsMutuallyFollowsBeforePublish(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{
+		// The follow state is checked first so restarts do not re-PUT
+		// existing friendships; the 204 here fails decoding, so both follows
+		// proceed.
+		"GET https://peoplehub.xboxlive.com/users/me/people/followers auth=",
 		"PUT https://social.xboxlive.com/users/me/people/xuid(200) auth=",
 		"PUT https://social.xboxlive.com/users/me/people/xuid(100) auth=",
 		"publish",
 	}
 	if fmt.Sprint(calls) != fmt.Sprint(want) {
 		t.Fatalf("unexpected call order\n got: %v\nwant: %v", calls, want)
+	}
+}
+
+func TestBroadcasterStartSubAccountsSkipsExistingMutualFollow(t *testing.T) {
+	var calls []string
+	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls = append(calls, req.Method+" "+req.URL.Path)
+		switch req.URL.Host {
+		case "peoplehub.xboxlive.com":
+			return broadcasterResponse(http.StatusOK, `{"people":[{"xuid":"100","isFollowingCaller":true,"isFollowedByCaller":true}]}`), nil
+		default:
+			t.Fatalf("unexpected request %s %s", req.Method, req.URL)
+			return nil, nil
+		}
+	})}
+	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{
+		XBLClient:  &xsapi.Client{},
+		XUID:       "100",
+		HTTPClient: client,
+		SubAccounts: []SubAccountConfig{{
+			ID:        "sub",
+			Enabled:   true,
+			XBLClient: &xsapi.Client{},
+			XUID:      "200",
+		}},
+	}}
+	b.subAccountPublisher = func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error) {
+		calls = append(calls, "publish")
+		return &mpsd.Session{}, nil
+	}
+
+	if err := b.startSubAccounts(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range calls {
+		if strings.HasPrefix(call, "PUT ") {
+			t.Fatalf("existing mutual follow should not be re-PUT, got calls %v", calls)
+		}
+	}
+	if calls[len(calls)-1] != "publish" {
+		t.Fatalf("expected publish after follow check, got %v", calls)
+	}
+}
+
+func TestBroadcasterStartSubAccountsContinuesPastFailingAccount(t *testing.T) {
+	var published []string
+	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{
+		XBLClient: &xsapi.Client{},
+		XUID:      "100",
+		SubAccounts: []SubAccountConfig{
+			{ID: "bad", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
+			{ID: "good", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
+		},
+	}}
+	b.subAccountPublisher = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference, _ mpsd.PublishConfig) (*mpsd.Session, error) {
+		if account.ID == "bad" {
+			return nil, errors.New("boom")
+		}
+		published = append(published, account.ID)
+		return &mpsd.Session{}, nil
+	}
+
+	if err := b.startSubAccounts(context.Background()); err != nil {
+		t.Fatalf("startSubAccounts() error = %v, want nil (bad account skipped)", err)
+	}
+	if fmt.Sprint(published) != "[good]" {
+		t.Fatalf("published = %v, want [good]", published)
 	}
 }
 
@@ -226,6 +297,9 @@ func TestMinecraftListenConfigKeepsFullLoginFlow(t *testing.T) {
 	conf := b.minecraftListenConfig(room.Status{HostName: "Host", WorldName: "World"})
 	if conf.DisablePacketHandling {
 		t.Fatal("expected listener to wait for resource-pack login flow")
+	}
+	if conf.AuthenticationDisabled {
+		t.Fatal("client authentication should be enabled by default so recorded XUIDs are verified")
 	}
 	if conf.CompressionThreshold != -1 {
 		t.Fatalf("CompressionThreshold = %d, want -1 for Java-compatible threshold 0", conf.CompressionThreshold)

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -105,6 +105,58 @@ func TestBroadcasterStartSubAccountsSkipsExistingMutualFollow(t *testing.T) {
 	}
 }
 
+func TestBroadcasterStartSubAccountsStopsQuietlyOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var notified []string
+	var started []string
+	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{
+		XBLClient: &xsapi.Client{},
+		XUID:      "100",
+		Notifier: fakeNotifier{notify: func(_ context.Context, message string) {
+			notified = append(notified, message)
+		}},
+		SubAccounts: []SubAccountConfig{
+			{ID: "first", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
+			{ID: "second", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
+		},
+	}}
+	b.subAccountPublisher = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference, _ mpsd.PublishConfig) (*mpsd.Session, error) {
+		started = append(started, account.ID)
+		cancel()
+		return nil, ctx.Err()
+	}
+
+	err := b.startSubAccounts(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("startSubAccounts() error = %v, want context.Canceled", err)
+	}
+	if fmt.Sprint(started) != "[first]" {
+		t.Fatalf("started = %v, want [first] (stop after cancellation)", started)
+	}
+	if len(notified) != 0 {
+		t.Fatalf("notifications = %v, want none during shutdown", notified)
+	}
+}
+
+func TestBroadcasterPrimarySyncerDisablesPruningWithSubAccountSyncers(t *testing.T) {
+	conf := Config{
+		XBLClient:  &xsapi.Client{},
+		XUID:       "100",
+		FriendSync: &FriendSyncConfig{AutoFollow: true, ExpiryEnabled: true},
+	}
+
+	solo := &Broadcaster{log: testBroadcasterLogger(), conf: conf}
+	if !solo.friendSyncer().PruneHistory {
+		t.Fatal("primary syncer should prune when it owns the history store alone")
+	}
+
+	conf.SubAccounts = []SubAccountConfig{{ID: "sub", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "200"}}
+	shared := &Broadcaster{log: testBroadcasterLogger(), conf: conf}
+	if shared.friendSyncer().PruneHistory {
+		t.Fatal("primary syncer must not prune a history store shared with sub-account syncers")
+	}
+}
+
 func TestBroadcasterStartSubAccountsContinuesPastFailingAccount(t *testing.T) {
 	var published []string
 	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{

--- a/cmd/broadcaster/main.go
+++ b/cmd/broadcaster/main.go
@@ -36,9 +36,9 @@ type commandDeps struct {
 	HTTPClient         *http.Client
 	LoadConfig         func(string) (broadcaster.ConfigFile, error)
 	LoadLiveToken      func(string) (*oauth2.Token, error)
-	NewLiveTokenSource func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource
+	NewLiveTokenSource func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource
 	SaveLiveToken      func(string, *oauth2.Token) error
-	LoadAccountToken   func(context.Context, string, io.Writer) (oauth2.TokenSource, error)
+	LoadAccountToken   func(context.Context, string, io.Writer, func(*oauth2.Token)) (oauth2.TokenSource, error)
 	NewXBLTokenSource  func(context.Context, oauth2.TokenSource) xsapi.TokenSource
 	NewXSAPIClient     func(context.Context, xsapi.TokenSource, *http.Client, *slog.Logger) (*xsapi.Client, error)
 	CloseXSAPIClients  func(*slog.Logger, []*xsapi.Client)
@@ -91,6 +91,9 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 	}
 	log := slog.New(slog.NewTextHandler(deps.Stdout, &slog.HandlerOptions{Level: level}))
 	log.Debug("debug logging enabled")
+	for _, note := range cfg.Notes {
+		log.Warn("config adjusted", "note", note)
+	}
 	var xblClients []*xsapi.Client
 	defer func() {
 		deps.CloseXSAPIClients(log, xblClients)
@@ -102,11 +105,19 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 		return err
 	}
 
+	var notifier broadcaster.Notifier
+	if cfg.Notifications.Enabled {
+		notifier = broadcaster.SlackNotifier{WebhookURL: cfg.Notifications.WebhookURL, Client: httpClient}
+	}
+	// Sign-in prompts (device-code URL and code) also go to the webhook so a
+	// headless instance whose token dies can still be recovered.
+	authOut := signInWriter(deps.Stdout, notifier, log)
+
 	tok, err := deps.LoadLiveToken(cachePath)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Warn("could not load token cache", "err", err)
 	}
-	live := deps.NewLiveTokenSource(authCtx, tok, deps.Stdout)
+	live := deps.NewLiveTokenSource(authCtx, tok, authOut, savePersistedToken(log, deps.SaveLiveToken, cachePath))
 	tok, err = live.Token()
 	if err != nil {
 		return fmt.Errorf("authenticate: %w", err)
@@ -122,13 +133,12 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 	xblClients = append(xblClients, xblClient)
 
 	runtime, err := cfg.RuntimeConfig(broadcaster.RuntimeConfigInput{
-		XBLClient:       xblClient,
-		XBLTokenSource:  xblSource,
-		XUID:            xblClient.UserInfo().XUID,
-		LiveTokenSource: live,
-		HTTPClient:      httpClient,
-		Log:             log,
-		BaseDir:         baseDir,
+		XBLClient:      xblClient,
+		XBLTokenSource: xblSource,
+		XUID:           xblClient.UserInfo().XUID,
+		HTTPClient:     httpClient,
+		Log:            log,
+		BaseDir:        baseDir,
 	})
 	if err != nil {
 		return fmt.Errorf("configure: %w", err)
@@ -141,7 +151,7 @@ func runBroadcasterCommand(ctx context.Context, opts commandOptions, deps comman
 		if err != nil {
 			return fmt.Errorf("configure sub-account %q: %w", account.ID, err)
 		}
-		subLive, err := deps.LoadAccountToken(authCtx, subCachePath, deps.Stdout)
+		subLive, err := deps.LoadAccountToken(authCtx, subCachePath, authOut, savePersistedToken(log, deps.SaveLiveToken, subCachePath))
 		if err != nil {
 			return fmt.Errorf("authenticate sub-account %q: %w", account.ID, err)
 		}
@@ -194,7 +204,7 @@ func (d commandDeps) withDefaults() commandDeps {
 		d.LoadLiveToken = broadcaster.LoadLiveToken
 	}
 	if d.NewLiveTokenSource == nil {
-		d.NewLiveTokenSource = broadcaster.NewLiveTokenSource
+		d.NewLiveTokenSource = broadcaster.NewLiveTokenSourceWithPersist
 	}
 	if d.SaveLiveToken == nil {
 		d.SaveLiveToken = broadcaster.SaveLiveToken
@@ -261,17 +271,56 @@ func defaultCachePath() string {
 	return filepath.Join(dir, "mcxboxbroadcast-go", "live_token.json")
 }
 
-func loadAccountToken(ctx context.Context, path string, out io.Writer) (oauth2.TokenSource, error) {
+func loadAccountToken(ctx context.Context, path string, out io.Writer, persist func(*oauth2.Token)) (oauth2.TokenSource, error) {
 	tok, err := broadcaster.LoadLiveToken(path)
 	if err != nil {
 		tok = nil
 	}
-	src := broadcaster.NewLiveTokenSource(ctx, tok, out)
+	src := broadcaster.NewLiveTokenSourceWithPersist(ctx, tok, out, persist)
 	tok, err = src.Token()
 	if err != nil {
 		return nil, err
 	}
 	return src, broadcaster.SaveLiveToken(path, tok)
+}
+
+// savePersistedToken saves rotated tokens to the cache path, logging failures.
+func savePersistedToken(log *slog.Logger, save func(string, *oauth2.Token) error, path string) func(*oauth2.Token) {
+	return func(tok *oauth2.Token) {
+		if save == nil {
+			return
+		}
+		if err := save(path, tok); err != nil && log != nil {
+			log.Warn("could not save rotated token cache", "path", path, "err", err)
+		}
+	}
+}
+
+// signInWriter tees device-code sign-in prompts to the notifier so headless
+// instances surface re-authentication requests.
+func signInWriter(out io.Writer, notifier broadcaster.Notifier, log *slog.Logger) io.Writer {
+	if notifier == nil {
+		return out
+	}
+	return &notifyingWriter{out: out, notifier: notifier, log: log}
+}
+
+type notifyingWriter struct {
+	out      io.Writer
+	notifier broadcaster.Notifier
+	log      *slog.Logger
+}
+
+func (w *notifyingWriter) Write(p []byte) (int, error) {
+	message := strings.TrimSpace(string(p))
+	if message != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := w.notifier.Notify(ctx, message); err != nil && w.log != nil {
+			w.log.Warn("send sign-in notification", "err", err)
+		}
+		cancel()
+	}
+	return w.out.Write(p)
 }
 
 func subAccountCachePath(base string, account broadcaster.SubAccountFile) (string, error) {

--- a/cmd/broadcaster/main_test.go
+++ b/cmd/broadcaster/main_test.go
@@ -61,7 +61,7 @@ func TestRunBroadcasterCommandRejectsDuplicateSubAccountCacheBeforeAuth(t *testi
 			}}
 			return cfg, nil
 		},
-		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource {
 			authenticated = true
 			return staticOAuthTokenSource{}
 		},
@@ -86,8 +86,8 @@ func TestRunBroadcasterCommandStartsAndClosesBroadcaster(t *testing.T) {
 		Stdout: io.Discard,
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			cfg.Accounts.PrimaryCachePath = "cache/live_token.json"
 			cfg.Accounts.SubAccounts = []broadcaster.SubAccountFile{{
 				ID:      "alt",
@@ -98,13 +98,13 @@ func TestRunBroadcasterCommandStartsAndClosesBroadcaster(t *testing.T) {
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource {
 			return staticOAuthTokenSource{}
 		},
 		SaveLiveToken: func(string, *oauth2.Token) error {
 			return nil
 		},
-		LoadAccountToken: func(context.Context, string, io.Writer) (oauth2.TokenSource, error) {
+		LoadAccountToken: func(context.Context, string, io.Writer, func(*oauth2.Token)) (oauth2.TokenSource, error) {
 			return staticOAuthTokenSource{}, nil
 		},
 		NewXBLTokenSource: func(context.Context, oauth2.TokenSource) xsapi.TokenSource {
@@ -152,8 +152,8 @@ func TestRunBroadcasterCommandClosesXSAPIClientsWhenStartFails(t *testing.T) {
 		Stdout: io.Discard,
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			cfg.Accounts.SubAccounts = []broadcaster.SubAccountFile{{
 				ID:      "alt",
 				Enabled: true,
@@ -163,13 +163,13 @@ func TestRunBroadcasterCommandClosesXSAPIClientsWhenStartFails(t *testing.T) {
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource {
 			return staticOAuthTokenSource{}
 		},
 		SaveLiveToken: func(string, *oauth2.Token) error {
 			return nil
 		},
-		LoadAccountToken: func(context.Context, string, io.Writer) (oauth2.TokenSource, error) {
+		LoadAccountToken: func(context.Context, string, io.Writer, func(*oauth2.Token)) (oauth2.TokenSource, error) {
 			return staticOAuthTokenSource{}, nil
 		},
 		NewXBLTokenSource: func(context.Context, oauth2.TokenSource) xsapi.TokenSource {
@@ -206,14 +206,14 @@ func TestRunBroadcasterCommandAppliesConfiguredHTTPProxy(t *testing.T) {
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
 			cfg.HTTP.Proxy = "http://127.0.0.1:8080"
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			return cfg, nil
 		},
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource {
 			return staticOAuthTokenSource{}
 		},
 		SaveLiveToken: func(string, *oauth2.Token) error {
@@ -270,14 +270,14 @@ func TestRunBroadcasterCommandAppliesConfiguredHTTPProxyToPrimaryLiveTokenSource
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
 			cfg.HTTP.Proxy = "http://127.0.0.1:8080"
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			return cfg, nil
 		},
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(ctx context.Context, _ *oauth2.Token, _ io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(ctx context.Context, _ *oauth2.Token, _ io.Writer, _ func(*oauth2.Token)) oauth2.TokenSource {
 			gotLiveAuthClient, _ = ctx.Value(oauth2.HTTPClient).(*http.Client)
 			return staticOAuthTokenSource{}
 		},
@@ -323,8 +323,8 @@ func TestRunBroadcasterCommandAppliesConfiguredHTTPProxyToSubAccountTokenLoad(t 
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
 			cfg.HTTP.Proxy = "http://127.0.0.1:8080"
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			cfg.Accounts.SubAccounts = []broadcaster.SubAccountFile{{
 				ID:      "alt",
 				Enabled: true,
@@ -334,13 +334,13 @@ func TestRunBroadcasterCommandAppliesConfiguredHTTPProxyToSubAccountTokenLoad(t 
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(context.Context, *oauth2.Token, io.Writer, func(*oauth2.Token)) oauth2.TokenSource {
 			return staticOAuthTokenSource{}
 		},
 		SaveLiveToken: func(string, *oauth2.Token) error {
 			return nil
 		},
-		LoadAccountToken: func(ctx context.Context, _ string, _ io.Writer) (oauth2.TokenSource, error) {
+		LoadAccountToken: func(ctx context.Context, _ string, _ io.Writer, _ func(*oauth2.Token)) (oauth2.TokenSource, error) {
 			gotSubAccountAuthClient, _ = ctx.Value(oauth2.HTTPClient).(*http.Client)
 			return staticOAuthTokenSource{}, nil
 		},
@@ -384,14 +384,14 @@ func TestRunBroadcasterCommandPreservesHTTPClientWithoutConfiguredProxy(t *testi
 		HTTPClient: baseClient,
 		LoadConfig: func(string) (broadcaster.ConfigFile, error) {
 			cfg := broadcaster.DefaultConfigFile()
-			cfg.Session.RemoteAddress = "127.0.0.1"
-			cfg.Session.RemotePort = "19132"
+			cfg.Session.SessionInfo.IP = "127.0.0.1"
+			cfg.Session.SessionInfo.Port = 19132
 			return cfg, nil
 		},
 		LoadLiveToken: func(string) (*oauth2.Token, error) {
 			return nil, errors.ErrUnsupported
 		},
-		NewLiveTokenSource: func(ctx context.Context, _ *oauth2.Token, _ io.Writer) oauth2.TokenSource {
+		NewLiveTokenSource: func(ctx context.Context, _ *oauth2.Token, _ io.Writer, _ func(*oauth2.Token)) oauth2.TokenSource {
 			gotLiveAuthClient, _ = ctx.Value(oauth2.HTTPClient).(*http.Client)
 			return staticOAuthTokenSource{}
 		},

--- a/config.example.yml
+++ b/config.example.yml
@@ -6,20 +6,20 @@ http:
   proxy: ""
 
 session:
-  remoteAddress: auto
-  remotePort: auto
   updateInterval: 30
   signalingMode: jsonrpc
   queryServer: true
   webQueryFallback: false
-  configFallback: true
+  # false keeps the last successful query result when a query fails;
+  # true resets the displayed values back to sessionInfo instead.
+  configFallback: false
   broadcastSetting: 3
   joinability: JoinableByFriends
   worldType: Survival
   sessionInfo:
     hostName: Minecraft Server
     worldName: Minecraft World
-    players: 1
+    players: 0
     maxPlayers: 20
     ip: play.example.net
     port: 19132

--- a/config.go
+++ b/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/p2p"
 	"github.com/sandertv/gophertunnel/minecraft/room"
 	"github.com/sandertv/gophertunnel/minecraft/service"
-	"golang.org/x/oauth2"
 )
 
 // Config holds the dependencies and settings for a Broadcaster.
@@ -29,9 +28,6 @@ type Config struct {
 	// XUID is the primary account's Xbox user ID. If empty, it is read from
 	// XBLClient when available.
 	XUID string
-	// LiveTokenSource supplies Microsoft Live tokens for compatibility with
-	// callers that still need to manage the underlying Microsoft auth cache.
-	LiveTokenSource oauth2.TokenSource
 	// MinecraftTokenSource supplies Minecraft franchise service tokens for
 	// signaling and gallery/profile image requests.
 	MinecraftTokenSource service.TokenSource
@@ -81,6 +77,10 @@ type Config struct {
 	// UpdateInterval controls the background session refresh interval. Values
 	// lower than 20 seconds are raised to 20 seconds to avoid Xbox rate limits.
 	UpdateInterval time.Duration
+	// TransferCloseTimeout bounds how long transferred clients are held open
+	// waiting for their disconnect. Zero uses a 15-second default; negative
+	// values disable the wait.
+	TransferCloseTimeout time.Duration
 	// HTTPClient is used by auth/signaling/session requests where supported.
 	HTTPClient *http.Client
 	// SignalingDialTimeout bounds default signaling startup. If zero, a
@@ -166,23 +166,23 @@ type Notifier interface {
 }
 
 type FriendSyncConfig struct {
-	UpdateInterval  time.Duration
-	AutoFollow      bool
-	AutoUnfollow    bool
-	InitialInvite   bool
-	ExpiryEnabled   bool
-	ExpiryDays      int
-	ExpiryCheck     time.Duration
-	IgnoreGuestXUID bool
+	UpdateInterval time.Duration
+	AutoFollow     bool
+	AutoUnfollow   bool
+	InitialInvite  bool
+	ExpiryEnabled  bool
+	ExpiryDays     int
+	ExpiryCheck    time.Duration
 }
 
 type SubAccountConfig struct {
-	ID              string
-	Enabled         bool
-	XBLClient       *xsapi.Client
-	XBLTokenSource  xsapi.TokenSource
-	XUID            string
-	LiveTokenSource oauth2.TokenSource
-	PublishConfig   mpsd.PublishConfig
-	FriendSync      *FriendSyncConfig
+	ID             string
+	Enabled        bool
+	XBLClient      *xsapi.Client
+	XBLTokenSource xsapi.TokenSource
+	XUID           string
+	PublishConfig  mpsd.PublishConfig
+	// FriendSync overrides the primary account's friend sync configuration for
+	// this sub-account. If nil, the primary configuration is used.
+	FriendSync *FriendSyncConfig
 }

--- a/config_file.go
+++ b/config_file.go
@@ -1,16 +1,13 @@
 package broadcaster
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,7 +15,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/service"
-	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -34,15 +30,20 @@ type ConfigFile struct {
 	Notifications                NotificationConfig `yaml:"notifications" toml:"notifications"`
 	Gallery                      GalleryFileConfig  `yaml:"gallery" toml:"gallery"`
 	Accounts                     AccountsConfig     `yaml:"accounts" toml:"accounts"`
+
+	// Notes lists adjustments applied while loading, such as out-of-range
+	// values that were clamped. Callers should surface them as warnings.
+	Notes []string `yaml:"-" toml:"-"`
 }
 
 type HTTPFileConfig struct {
 	Proxy string `yaml:"proxy" toml:"proxy"`
 }
 
+// SessionFileConfig mirrors MCXboxBroadcast's standalone session settings.
+// The Geyser-extension-only remoteAddress/remotePort keys are intentionally
+// absent; the broadcast target always comes from sessionInfo.
 type SessionFileConfig struct {
-	RemoteAddress    string          `yaml:"remoteAddress" toml:"remoteAddress"`
-	RemotePort       string          `yaml:"remotePort" toml:"remotePort"`
 	UpdateInterval   int             `yaml:"updateInterval" toml:"updateInterval"`
 	SignalingMode    string          `yaml:"signalingMode" toml:"signalingMode"`
 	QueryServer      bool            `yaml:"queryServer" toml:"queryServer"`
@@ -104,35 +105,29 @@ type RuntimeConfigInput struct {
 	XBLClient            *xsapi.Client
 	XBLTokenSource       xsapi.TokenSource
 	XUID                 string
-	LiveTokenSource      oauth2.TokenSource
 	MinecraftTokenSource service.TokenSource
 	HTTPClient           *http.Client
 	Log                  *slog.Logger
 	BaseDir              string
-	RemoteAddress        string
-	RemotePort           uint16
-	PublicIPResolver     func(context.Context) (string, error)
 }
 
 func DefaultConfigFile() ConfigFile {
 	return ConfigFile{
 		ConfigVersion: CurrentConfigVersion,
-		DebugMode:     true,
+		DebugMode:     false,
 		Session: SessionFileConfig{
-			RemoteAddress:    "auto",
-			RemotePort:       "auto",
 			UpdateInterval:   30,
 			SignalingMode:    string(SignalingModeJSONRPC),
 			QueryServer:      true,
 			WebQueryFallback: false,
-			ConfigFallback:   true,
+			ConfigFallback:   false,
 			BroadcastSetting: int32(BroadcastSettingFriendsOfFriends),
 			Joinability:      JoinabilityJoinableByFriends,
 			WorldType:        WorldTypeSurvival,
 			SessionInfo: SessionInfoFile{
 				HostName:   "Minecraft Server",
 				WorldName:  "Minecraft World",
-				Players:    1,
+				Players:    0,
 				MaxPlayers: 20,
 				IP:         "play.example.net",
 				Port:       19132,
@@ -214,7 +209,13 @@ func LoadConfigFile(path string) (ConfigFile, error) {
 	if err := decodeConfig(path, data, &cfg); err != nil {
 		return ConfigFile{}, err
 	}
+	loadedVersion := cfg.ConfigVersion
 	cfg.migrate()
+	if loadedVersion != cfg.ConfigVersion {
+		if err := SaveConfigFile(path, cfg); err != nil {
+			cfg.Notes = append(cfg.Notes, fmt.Sprintf("could not persist migrated config: %v", err))
+		}
+	}
 	return cfg, nil
 }
 
@@ -234,15 +235,19 @@ func (c *ConfigFile) migrate() {
 		c.ConfigVersion = CurrentConfigVersion
 	}
 	if c.Session.UpdateInterval < 20 {
+		c.note("session.updateInterval %d is below the 20 second minimum; using 20", c.Session.UpdateInterval)
 		c.Session.UpdateInterval = 20
 	}
 	if c.FriendSync.UpdateInterval < 20 {
+		c.note("friendSync.updateInterval %d is below the 20 second minimum; using 20", c.FriendSync.UpdateInterval)
 		c.FriendSync.UpdateInterval = 20
 	}
 	if c.FriendSync.Expiry.Days <= 0 {
+		c.note("friendSync.expiry.days %d is invalid; using 15", c.FriendSync.Expiry.Days)
 		c.FriendSync.Expiry.Days = 15
 	}
 	if c.FriendSync.Expiry.Check <= 0 {
+		c.note("friendSync.expiry.check %d is invalid; using 1800", c.FriendSync.Expiry.Check)
 		c.FriendSync.Expiry.Check = 1800
 	}
 	if c.FriendSync.Expiry.HistoryPath == "" {
@@ -253,14 +258,15 @@ func (c *ConfigFile) migrate() {
 	}
 }
 
+func (c *ConfigFile) note(format string, args ...any) {
+	c.Notes = append(c.Notes, fmt.Sprintf(format, args...))
+}
+
 func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 	if in.BaseDir == "" {
 		in.BaseDir = "."
 	}
-	server, err := c.serverInfo(context.Background(), in)
-	if err != nil {
-		return Config{}, err
-	}
+	server := ServerInfo{Host: c.Session.SessionInfo.IP, Port: c.Session.SessionInfo.Port}
 	signalingMode, err := configSignalingMode(c.Session.SignalingMode)
 	if err != nil {
 		return Config{}, err
@@ -269,7 +275,6 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 		XBLClient:            in.XBLClient,
 		XBLTokenSource:       in.XBLTokenSource,
 		XUID:                 in.XUID,
-		LiveTokenSource:      in.LiveTokenSource,
 		MinecraftTokenSource: in.MinecraftTokenSource,
 		Server:               server,
 		Status: Status{
@@ -327,44 +332,18 @@ func configSignalingMode(mode string) (SignalingMode, error) {
 	}
 }
 
-func (c ConfigFile) serverInfo(ctx context.Context, in RuntimeConfigInput) (ServerInfo, error) {
-	host := c.Session.SessionInfo.IP
-	if c.Session.RemoteAddress != "" && c.Session.RemoteAddress != "auto" {
-		host = c.Session.RemoteAddress
-	} else if c.Session.RemoteAddress == "auto" && in.RemoteAddress != "" {
-		host = in.RemoteAddress
-		if in.PublicIPResolver != nil && isPrivateHost(host) {
-			if public, err := in.PublicIPResolver(ctx); err == nil && public != "" {
-				host = public
-			}
-		}
-	}
-	port := c.Session.SessionInfo.Port
-	if c.Session.RemotePort != "" && c.Session.RemotePort != "auto" {
-		n, err := strconv.ParseUint(c.Session.RemotePort, 10, 16)
-		if err != nil {
-			return ServerInfo{}, fmt.Errorf("parse remote port: %w", err)
-		}
-		port = uint16(n)
-	} else if c.Session.RemotePort == "auto" && in.RemotePort != 0 {
-		port = in.RemotePort
-	}
-	return ServerInfo{Host: host, Port: port}, nil
-}
-
 func (f FriendFileConfig) runtime() *FriendSyncConfig {
 	if !f.AutoFollow && !f.AutoUnfollow && !f.Expiry.Enabled {
 		return nil
 	}
 	return &FriendSyncConfig{
-		UpdateInterval:  time.Duration(f.UpdateInterval) * time.Second,
-		AutoFollow:      f.AutoFollow,
-		AutoUnfollow:    f.AutoUnfollow,
-		InitialInvite:   f.InitialInvite,
-		ExpiryEnabled:   f.Expiry.Enabled,
-		ExpiryDays:      f.Expiry.Days,
-		ExpiryCheck:     time.Duration(f.Expiry.Check) * time.Second,
-		IgnoreGuestXUID: true,
+		UpdateInterval: time.Duration(f.UpdateInterval) * time.Second,
+		AutoFollow:     f.AutoFollow,
+		AutoUnfollow:   f.AutoUnfollow,
+		InitialInvite:  f.InitialInvite,
+		ExpiryEnabled:  f.Expiry.Enabled,
+		ExpiryDays:     f.Expiry.Days,
+		ExpiryCheck:    time.Duration(f.Expiry.Check) * time.Second,
 	}
 }
 
@@ -579,12 +558,4 @@ func resolvePath(base, path string) string {
 		return path
 	}
 	return filepath.Join(base, path)
-}
-
-func isPrivateHost(host string) bool {
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return false
-	}
-	return ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified()
 }

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -116,9 +116,6 @@ accounts:
 	if !cfg.DebugMode || !cfg.SuppressSessionUpdateMessage {
 		t.Fatalf("top-level kebab-case aliases were not loaded: %#v", cfg)
 	}
-	if cfg.Session.RemoteAddress != "bedrock.example.net" || cfg.Session.RemotePort != "19133" {
-		t.Fatalf("session remote aliases were not loaded: %#v", cfg.Session)
-	}
 	if cfg.Session.UpdateInterval != 45 || cfg.Session.QueryServer || !cfg.Session.WebQueryFallback || cfg.Session.ConfigFallback {
 		t.Fatalf("session query aliases were not loaded: %#v", cfg.Session)
 	}
@@ -171,7 +168,7 @@ friend-sync:
 	if !cfg.DebugMode || !cfg.SuppressSessionUpdateMessage {
 		t.Fatalf("legacy top-level aliases were not migrated: %#v", cfg)
 	}
-	if cfg.Session.RemoteAddress != "legacy.example.net" || cfg.Session.RemotePort != "19135" || cfg.Session.UpdateInterval != 55 {
+	if cfg.Session.UpdateInterval != 55 {
 		t.Fatalf("legacy session keys were not moved: %#v", cfg.Session)
 	}
 	if cfg.FriendSync.Expiry.Enabled || cfg.FriendSync.Expiry.Days != 30 || cfg.FriendSync.Expiry.Check != 3600 {
@@ -211,8 +208,7 @@ func TestConfigFileToConfigMapsOperatorSettings(t *testing.T) {
 	cfg.Gallery.ImagePath = "images/showcase.jpg"
 
 	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
+		XBLTokenSource: staticTokenSource{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -245,8 +241,7 @@ func TestConfigFileMapsSuppressSessionUpdateMessage(t *testing.T) {
 	cfg.SuppressSessionUpdateMessage = true
 
 	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
+		XBLTokenSource: staticTokenSource{},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -260,8 +255,7 @@ func TestConfigFileRejectsWebSocketSignalingMode(t *testing.T) {
 	cfg := DefaultConfigFile()
 	cfg.Session.SignalingMode = "websocket"
 	_, err := cfg.RuntimeConfig(RuntimeConfigInput{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
+		XBLTokenSource: staticTokenSource{},
 	})
 	if err == nil {
 		t.Fatal("expected websocket signaling mode error")
@@ -278,8 +272,7 @@ func TestConfigFileDisablesFriendSyncWhenNoActionsConfigured(t *testing.T) {
 	cfg.FriendSync.Expiry.Enabled = false
 
 	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
+		XBLTokenSource: staticTokenSource{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/friend_sync.go
+++ b/friend_sync.go
@@ -21,6 +21,12 @@ type pendingFriendRequestAccepter interface {
 	AcceptPendingFriendRequests(ctx context.Context) ([]Person, error)
 }
 
+// forceUnfollower drops a follower whose account restrictions prevent a
+// friendship, so the person is not retried on every sync pass.
+type forceUnfollower interface {
+	ForceUnfollow(ctx context.Context, xuid string) error
+}
+
 type Inviter interface {
 	Invite(ctx context.Context, xuid, titleID string) error
 }
@@ -34,12 +40,25 @@ type HistoryRecorder interface {
 	Seen(ctx context.Context, xuid string, when time.Time) error
 }
 
+// HistoryLister enumerates all recorded XUIDs so history can be reconciled
+// against the current friend list.
+type HistoryLister interface {
+	XUIDs(ctx context.Context) ([]string, error)
+}
+
 type FriendSyncer struct {
 	Client  FriendAPI
 	Config  FriendSyncConfig
 	Inviter Inviter
 	History HistoryStore
-	Log     *slog.Logger
+	// Notifier receives operator-facing notifications such as friend
+	// restriction removals. It may be nil.
+	Notifier Notifier
+	// PruneHistory removes history entries for people missing from this
+	// syncer's friend list. Enable it on exactly one syncer per shared
+	// HistoryStore, or entries maintained by other accounts get dropped.
+	PruneHistory bool
+	Log          *slog.Logger
 }
 
 const friendListFullBackoff = time.Hour
@@ -50,75 +69,65 @@ type friendSyncOptions struct {
 	autoUnfollow bool
 }
 
+// friendSyncRunState tracks per-operation rate-limit backoff between runs.
+// Follow and unfollow limits are tracked separately because Xbox applies them
+// independently; a rate-limited add pass must not stall removals or scans.
 type friendSyncRunState struct {
-	retryUntil      time.Time
-	autoFollowUntil time.Time
+	followRetryUntil   time.Time
+	unfollowRetryUntil time.Time
+	autoFollowUntil    time.Time
 }
 
 func (s *friendSyncRunState) options(now time.Time, expire bool) friendSyncOptions {
-	mutationsAllowed := !s.backingOff(now)
 	return friendSyncOptions{
 		expire:       expire,
-		autoFollow:   mutationsAllowed && !now.Before(s.autoFollowUntil),
-		autoUnfollow: mutationsAllowed,
+		autoFollow:   !now.Before(s.followRetryUntil) && !now.Before(s.autoFollowUntil),
+		autoUnfollow: !now.Before(s.unfollowRetryUntil),
 	}
 }
 
-func (s *friendSyncRunState) backingOff(now time.Time) bool {
-	return now.Before(s.retryUntil)
-}
-
-func (s *friendSyncRunState) recordError(now time.Time, err error) {
-	if delay := retryDelay(err); delay > 0 {
-		s.retryUntil = now.Add(delay)
+func (s *friendSyncRunState) record(now time.Time, result friendSyncResult) {
+	if result.followRetryAfter > 0 {
+		s.followRetryUntil = now.Add(result.followRetryAfter)
 	}
-	if errors.Is(err, xblsocial.ErrFriendListFull) {
+	if result.unfollowRetryAfter > 0 {
+		s.unfollowRetryUntil = now.Add(result.unfollowRetryAfter)
+	}
+	if result.friendListFull {
 		s.autoFollowUntil = now.Add(friendListFullBackoff)
 	}
 }
 
-func (s FriendSyncer) Sync(ctx context.Context) error {
-	return s.sync(ctx, true)
+// friendSyncResult carries the rate-limit outcomes of a sync pass.
+type friendSyncResult struct {
+	followRetryAfter   time.Duration
+	unfollowRetryAfter time.Duration
+	friendListFull     bool
 }
 
-func (s FriendSyncer) sync(ctx context.Context, expire bool) error {
-	return s.syncWithOptions(ctx, friendSyncOptions{
-		expire:       expire,
+func (s FriendSyncer) Sync(ctx context.Context) error {
+	_, err := s.syncWithOptions(ctx, friendSyncOptions{
+		expire:       true,
 		autoFollow:   true,
 		autoUnfollow: true,
 	})
+	return err
 }
 
-func (s FriendSyncer) syncWithOptions(ctx context.Context, opts friendSyncOptions) error {
+func (s FriendSyncer) syncWithOptions(ctx context.Context, opts friendSyncOptions) (friendSyncResult, error) {
+	var result friendSyncResult
 	if s.Client == nil {
-		return nil
+		return result, nil
 	}
 	if s.Config.InitialInvite && s.Inviter == nil {
 		s.debug(ctx, "initial invite unavailable", "reason", "session inviter is not configured")
 	}
 	if s.Config.AutoFollow && opts.autoFollow {
-		if accepter, ok := s.Client.(pendingFriendRequestAccepter); ok {
-			s.debug(ctx, "accepting pending friend requests")
-			accepted, err := accepter.AcceptPendingFriendRequests(ctx)
-			for _, p := range accepted {
-				s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag, "source", "pending_requests")
-			}
-			if s.Config.InitialInvite && s.Inviter != nil {
-				for _, p := range accepted {
-					s.sendInitialInvite(ctx, p, "pending_requests")
-				}
-			}
-			if err != nil {
-				if shouldStopPendingFriendAccept(err) {
-					return err
-				}
-				s.logPendingFriendAcceptError(err)
-			}
-		}
+		s.acceptPending(ctx, &result)
 	}
 	people, err := s.Client.Friends(ctx)
 	if err != nil {
-		return err
+		return result, err
 	}
 	stats := s.friendSyncStats(people, opts)
 	s.debug(ctx, "friend sync scan",
@@ -138,60 +147,31 @@ func (s FriendSyncer) syncWithOptions(ctx context.Context, opts friendSyncOption
 	added := 0
 	removed := 0
 	for _, p := range people {
-		if s.Config.IgnoreGuestXUID && isGuestXUID(p.XUID) {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if isGuestXUID(p.XUID) {
 			continue
 		}
-		if s.Config.AutoFollow && opts.autoFollow && p.IsFollowingCaller && !p.IsFollowedByCaller {
-			if err := s.Client.Follow(ctx, p.XUID); err != nil {
-				s.logFriendSyncError("follow", p, err)
-				s.debug(ctx, "failed to add friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
-				return err
-			}
-			added++
-			s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag)
-			if s.Config.InitialInvite && s.Inviter != nil {
-				s.sendInitialInvite(ctx, p, "auto_follow")
+		if s.Config.AutoFollow && opts.autoFollow && !result.followBlocked() && p.IsFollowingCaller && !p.IsFollowedByCaller {
+			if s.follow(ctx, p, &result) {
+				added++
 			}
 		}
-		if s.Config.AutoUnfollow && opts.autoUnfollow && !p.IsFollowingCaller && p.IsFollowedByCaller {
-			if err := s.Client.Unfollow(ctx, p.XUID); err != nil {
-				s.debug(ctx, "failed to remove friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
-				return err
-			}
-			removed++
-			s.info(ctx, "removed friend", "xuid", p.XUID, "gamertag", p.Gamertag)
-			if s.History != nil {
-				_ = s.History.Clear(ctx, p.XUID)
+		if s.Config.AutoUnfollow && opts.autoUnfollow && !result.unfollowBlocked() && !p.IsFollowingCaller && p.IsFollowedByCaller {
+			if s.unfollow(ctx, p, "", &result) {
+				removed++
 			}
 			continue
 		}
-		if opts.expire && opts.autoUnfollow && s.Config.ExpiryEnabled && p.IsFollowedByCaller && s.History != nil {
-			lastSeen, ok, err := s.History.LastSeen(ctx, p.XUID)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				if recorder, ok := s.History.(HistoryRecorder); ok {
-					if err := recorder.Seen(ctx, p.XUID, time.Now()); err != nil {
-						return err
-					}
-				}
-				continue
-			}
-			expiryDays := s.Config.ExpiryDays
-			if expiryDays <= 0 {
-				expiryDays = 15
-			}
-			if ok && lastSeen.Before(time.Now().Add(-time.Duration(expiryDays)*24*time.Hour)) {
-				s.info(ctx, "removing inactive friend", "xuid", p.XUID, "gamertag", p.Gamertag, "last_seen", lastSeen)
-				if err := s.Client.Unfollow(ctx, p.XUID); err != nil {
-					s.debug(ctx, "failed to remove inactive friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
-					return err
-				}
-				s.info(ctx, "removed friend", "xuid", p.XUID, "gamertag", p.Gamertag, "reason", "inactive")
-				_ = s.History.Clear(ctx, p.XUID)
+		if opts.expire && opts.autoUnfollow && !result.unfollowBlocked() && s.Config.ExpiryEnabled && p.IsFollowedByCaller && s.History != nil {
+			if s.expire(ctx, p, &result) {
+				removed++
 			}
 		}
+	}
+	if opts.expire && s.Config.ExpiryEnabled && s.PruneHistory {
+		s.pruneHistory(ctx, people)
 	}
 	if stats.autoFollowCandidates > 0 {
 		s.debug(ctx, "added friends", "count", added)
@@ -199,7 +179,167 @@ func (s FriendSyncer) syncWithOptions(ctx context.Context, opts friendSyncOption
 	if stats.autoUnfollowCandidates > 0 {
 		s.debug(ctx, "removed friends", "count", removed)
 	}
-	return nil
+	return result, nil
+}
+
+func (r friendSyncResult) followBlocked() bool {
+	return r.followRetryAfter > 0 || r.friendListFull
+}
+
+func (r friendSyncResult) unfollowBlocked() bool {
+	return r.unfollowRetryAfter > 0
+}
+
+// acceptPending accepts incoming friend requests, sending initial invites for
+// each accepted person when configured.
+func (s FriendSyncer) acceptPending(ctx context.Context, result *friendSyncResult) {
+	accepter, ok := s.Client.(pendingFriendRequestAccepter)
+	if !ok {
+		return
+	}
+	s.debug(ctx, "accepting pending friend requests")
+	accepted, err := accepter.AcceptPendingFriendRequests(ctx)
+	for _, p := range accepted {
+		s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag, "source", "pending_requests")
+	}
+	if s.Config.InitialInvite && s.Inviter != nil {
+		for _, p := range accepted {
+			s.sendInitialInvite(ctx, p, "pending_requests")
+		}
+	}
+	if err != nil {
+		if delay := retryDelay(err); delay > 0 {
+			result.followRetryAfter = delay
+		}
+		s.logPendingFriendAcceptError(err)
+	}
+}
+
+// follow follows p back and reports whether the friendship was established.
+// Restricted accounts are force-unfollowed so they are not retried forever.
+func (s FriendSyncer) follow(ctx context.Context, p Person, result *friendSyncResult) bool {
+	err := s.Client.Follow(ctx, p.XUID)
+	if err == nil {
+		s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag)
+		if s.Config.InitialInvite && s.Inviter != nil {
+			s.sendInitialInvite(ctx, p, "auto_follow")
+		}
+		return true
+	}
+	s.logFriendSyncError("follow", p, err)
+	s.debug(ctx, "failed to add friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
+	switch {
+	case errors.Is(err, xblsocial.ErrFriendRestricted):
+		s.dropRestrictedFollower(ctx, p)
+	case errors.Is(err, xblsocial.ErrFriendListFull):
+		result.friendListFull = true
+	default:
+		if delay := retryDelay(err); delay > 0 {
+			result.followRetryAfter = delay
+		}
+	}
+	return false
+}
+
+// dropRestrictedFollower removes a privacy-restricted follower so the account
+// stops showing up as an auto-follow candidate on every pass.
+func (s FriendSyncer) dropRestrictedFollower(ctx context.Context, p Person) {
+	unfollower, ok := s.Client.(forceUnfollower)
+	if !ok {
+		return
+	}
+	if err := unfollower.ForceUnfollow(ctx, p.XUID); err != nil {
+		if s.Log != nil {
+			s.Log.Error("force unfollow restricted account", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
+		}
+		return
+	}
+	if s.History != nil {
+		_ = s.History.Clear(ctx, p.XUID)
+	}
+	s.warn(ctx, "removed friend due to restrictions on their account", "xuid", p.XUID, "gamertag", p.Gamertag)
+	s.notify(ctx, "Removed "+p.Gamertag+" ("+p.XUID+") as a friend due to restrictions on their account.")
+}
+
+// unfollow removes p and reports whether the removal succeeded.
+func (s FriendSyncer) unfollow(ctx context.Context, p Person, reason string, result *friendSyncResult) bool {
+	if err := s.Client.Unfollow(ctx, p.XUID); err != nil {
+		s.debug(ctx, "failed to remove friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
+		if delay := retryDelay(err); delay > 0 {
+			result.unfollowRetryAfter = delay
+		}
+		return false
+	}
+	if reason == "" {
+		s.info(ctx, "removed friend", "xuid", p.XUID, "gamertag", p.Gamertag)
+	} else {
+		s.info(ctx, "removed friend", "xuid", p.XUID, "gamertag", p.Gamertag, "reason", reason)
+	}
+	if s.History != nil {
+		_ = s.History.Clear(ctx, p.XUID)
+	}
+	return true
+}
+
+// expire removes p when they have not been seen within the expiry window and
+// reports whether a removal happened.
+func (s FriendSyncer) expire(ctx context.Context, p Person, result *friendSyncResult) bool {
+	lastSeen, ok, err := s.History.LastSeen(ctx, p.XUID)
+	if err != nil {
+		if s.Log != nil {
+			s.Log.Error("read player history", "xuid", p.XUID, "err", err)
+		}
+		return false
+	}
+	if !ok {
+		if recorder, ok := s.History.(HistoryRecorder); ok {
+			if err := recorder.Seen(ctx, p.XUID, time.Now()); err != nil && s.Log != nil {
+				s.Log.Error("record player history", "xuid", p.XUID, "err", err)
+			}
+		}
+		return false
+	}
+	expiryDays := s.Config.ExpiryDays
+	if expiryDays <= 0 {
+		expiryDays = 15
+	}
+	if !lastSeen.Before(time.Now().Add(-time.Duration(expiryDays) * 24 * time.Hour)) {
+		return false
+	}
+	s.info(ctx, "removing inactive friend", "xuid", p.XUID, "gamertag", p.Gamertag, "last_seen", lastSeen)
+	return s.unfollow(ctx, p, "inactive", result)
+}
+
+// pruneHistory drops history entries for people who are no longer on the
+// friend list so the store does not grow forever.
+func (s FriendSyncer) pruneHistory(ctx context.Context, people []Person) {
+	lister, ok := s.History.(HistoryLister)
+	if !ok {
+		return
+	}
+	xuids, err := lister.XUIDs(ctx)
+	if err != nil {
+		if s.Log != nil {
+			s.Log.Error("list player history", "err", err)
+		}
+		return
+	}
+	current := make(map[string]struct{}, len(people))
+	for _, p := range people {
+		current[p.XUID] = struct{}{}
+	}
+	for _, xuid := range xuids {
+		if _, ok := current[xuid]; ok {
+			continue
+		}
+		if err := s.History.Clear(ctx, xuid); err != nil {
+			if s.Log != nil {
+				s.Log.Error("prune player history", "xuid", xuid, "err", err)
+			}
+			continue
+		}
+		s.debug(ctx, "pruned player history for ex-friend", "xuid", xuid)
+	}
 }
 
 func (s FriendSyncer) sendInitialInvite(ctx context.Context, p Person, source string) {
@@ -224,7 +364,7 @@ type friendSyncStats struct {
 func (s FriendSyncer) friendSyncStats(people []Person, opts friendSyncOptions) friendSyncStats {
 	stats := friendSyncStats{people: len(people)}
 	for _, p := range people {
-		if s.Config.IgnoreGuestXUID && isGuestXUID(p.XUID) {
+		if isGuestXUID(p.XUID) {
 			continue
 		}
 		if p.IsFollowingCaller {
@@ -261,9 +401,26 @@ func (s FriendSyncer) logPendingFriendAcceptError(err error) {
 	}
 }
 
+func (s FriendSyncer) notify(ctx context.Context, message string) {
+	if s.Notifier == nil {
+		return
+	}
+	notifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	if err := s.Notifier.Notify(notifyCtx, message); err != nil && s.Log != nil {
+		s.Log.Error("send notification", "err", err)
+	}
+}
+
 func (s FriendSyncer) info(ctx context.Context, msg string, args ...any) {
 	if s.Log != nil {
 		s.Log.InfoContext(ctx, msg, args...)
+	}
+}
+
+func (s FriendSyncer) warn(ctx context.Context, msg string, args ...any) {
+	if s.Log != nil {
+		s.Log.WarnContext(ctx, msg, args...)
 	}
 }
 
@@ -271,10 +428,6 @@ func (s FriendSyncer) debug(ctx context.Context, msg string, args ...any) {
 	if s.Log != nil {
 		s.Log.DebugContext(ctx, msg, args...)
 	}
-}
-
-func shouldStopPendingFriendAccept(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || retryDelay(err) > 0
 }
 
 func retryDelay(err error) time.Duration {
@@ -319,23 +472,17 @@ func (s FriendSyncer) Run(ctx context.Context) {
 	}
 }
 
+// runSync executes one sync pass. Rate-limit backoff only suppresses the
+// affected mutation type; scans and the other mutation type keep running.
 func (s FriendSyncer) runSync(ctx context.Context, state *friendSyncRunState, expire bool) {
 	if state == nil {
 		state = &friendSyncRunState{}
 	}
-	now := time.Now()
-	if state.backingOff(now) {
-		s.debug(ctx, "friend sync backing off", "retry_until", state.retryUntil)
-		return
-	}
-	opts := state.options(now, expire)
+	opts := state.options(time.Now(), expire)
 	s.debug(ctx, "friend sync tick", "expire", expire, "auto_follow", opts.autoFollow, "auto_unfollow", opts.autoUnfollow)
-	err := s.syncWithOptions(ctx, opts)
-	if err == nil {
-		return
-	}
-	state.recordError(time.Now(), err)
-	if s.Log != nil {
+	result, err := s.syncWithOptions(ctx, opts)
+	state.record(time.Now(), result)
+	if err != nil && s.Log != nil && !errors.Is(err, context.Canceled) {
 		s.Log.Error("sync friends", "err", err)
 	}
 }

--- a/friend_sync_test.go
+++ b/friend_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -181,9 +182,12 @@ func TestFriendSyncerStopsAutoFollowPassWhenFriendListIsFull(t *testing.T) {
 		},
 		Log: slog.New(slog.NewTextHandler(&log, nil)),
 	}
-	err := syncer.Sync(context.Background())
-	if !errors.Is(err, fullErr) {
-		t.Fatalf("Sync() error = %v, want friend-list-full error", err)
+	result, err := syncer.syncWithOptions(context.Background(), friendSyncOptions{expire: true, autoFollow: true, autoUnfollow: true})
+	if err != nil {
+		t.Fatalf("syncWithOptions() error = %v, want nil", err)
+	}
+	if !result.friendListFull {
+		t.Fatal("expected friend-list-full result")
 	}
 	if client.followCalls != 1 {
 		t.Fatalf("follow calls = %d, want 1", client.followCalls)
@@ -193,14 +197,161 @@ func TestFriendSyncerStopsAutoFollowPassWhenFriendListIsFull(t *testing.T) {
 	}
 }
 
-func TestFriendSyncRunStateSuppressesMutationsDuringRetryAfter(t *testing.T) {
+func TestFriendSyncerContinuesPastSingleFollowFailure(t *testing.T) {
+	client := &syncFriendClient{
+		people: []Person{
+			{XUID: "1", IsFollowingCaller: true},
+			{XUID: "2", IsFollowingCaller: true},
+			{XUID: "3", IsFollowedByCaller: true},
+		},
+		follow: func(_ context.Context, xuid string) error {
+			if xuid == "1" {
+				return errors.New("transient failure")
+			}
+			return nil
+		},
+	}
+	syncer := FriendSyncer{
+		Client: client,
+		Config: FriendSyncConfig{AutoFollow: true, AutoUnfollow: true},
+	}
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync() error = %v, want nil", err)
+	}
+	if client.followCalls != 2 {
+		t.Fatalf("follow calls = %d, want 2 (continue past failure)", client.followCalls)
+	}
+	if client.removeCalls != 1 {
+		t.Fatalf("remove calls = %d, want 1 (removals not aborted)", client.removeCalls)
+	}
+}
+
+func TestFriendSyncerContinuesRemovalsWhenAddsAreRateLimited(t *testing.T) {
+	limitErr := &xblsocial.ResponseError{StatusCode: 429, RetryAfter: 5 * time.Second}
+	client := &syncFriendClient{
+		people: []Person{
+			{XUID: "1", IsFollowingCaller: true},
+			{XUID: "2", IsFollowingCaller: true},
+			{XUID: "3", IsFollowedByCaller: true},
+		},
+		follow: func(context.Context, string) error {
+			return limitErr
+		},
+	}
+	syncer := FriendSyncer{
+		Client: client,
+		Config: FriendSyncConfig{AutoFollow: true, AutoUnfollow: true},
+	}
+	result, err := syncer.syncWithOptions(context.Background(), friendSyncOptions{autoFollow: true, autoUnfollow: true})
+	if err != nil {
+		t.Fatalf("syncWithOptions() error = %v, want nil", err)
+	}
+	if client.followCalls != 1 {
+		t.Fatalf("follow calls = %d, want 1 (stop adds after rate limit)", client.followCalls)
+	}
+	if client.removeCalls != 1 {
+		t.Fatalf("remove calls = %d, want 1 (removals use a separate limit)", client.removeCalls)
+	}
+	if result.followRetryAfter != 5*time.Second {
+		t.Fatalf("follow retry-after = %s, want 5s", result.followRetryAfter)
+	}
+	if result.unfollowRetryAfter != 0 {
+		t.Fatalf("unfollow retry-after = %s, want 0", result.unfollowRetryAfter)
+	}
+}
+
+func TestFriendSyncerForceUnfollowsRestrictedAccounts(t *testing.T) {
+	restrictedErr := &xblsocial.ResponseError{Code: 1049}
+	var notified []string
+	client := &syncFriendClient{
+		people: []Person{
+			{XUID: "1", Gamertag: "Restricted", IsFollowingCaller: true},
+			{XUID: "2", Gamertag: "Fine", IsFollowingCaller: true},
+		},
+		follow: func(_ context.Context, xuid string) error {
+			if xuid == "1" {
+				return restrictedErr
+			}
+			return nil
+		},
+	}
+	syncer := FriendSyncer{
+		Client: client,
+		Config: FriendSyncConfig{AutoFollow: true},
+		Notifier: notifierFunc(func(_ context.Context, message string) error {
+			notified = append(notified, message)
+			return nil
+		}),
+	}
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync() error = %v, want nil", err)
+	}
+	if got := strings.Join(client.forceUnfollowed, ","); got != "1" {
+		t.Fatalf("force unfollowed = %q, want 1", got)
+	}
+	if client.followCalls != 2 {
+		t.Fatalf("follow calls = %d, want 2 (continue past restricted account)", client.followCalls)
+	}
+	if len(notified) != 1 || !strings.Contains(notified[0], "Restricted") {
+		t.Fatalf("notifications = %v, want restriction notification", notified)
+	}
+}
+
+func TestFriendSyncerSkipsGuestXUIDsUnconditionally(t *testing.T) {
+	guest := strconv.FormatUint(1<<52, 10)
+	client := &syncFriendClient{
+		people: []Person{{XUID: guest, IsFollowingCaller: true}},
+	}
+	syncer := FriendSyncer{
+		Client: client,
+		Config: FriendSyncConfig{AutoFollow: true},
+	}
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if client.followCalls != 0 {
+		t.Fatalf("follow calls = %d, want 0 (guest XUIDs always skipped)", client.followCalls)
+	}
+}
+
+func TestFriendSyncerPrunesHistoryForExFriends(t *testing.T) {
+	history := &syncHistoryStore{
+		lastSeen: map[string]time.Time{
+			"1":    time.Now(),
+			"gone": time.Now(),
+		},
+	}
+	client := &syncFriendClient{
+		people: []Person{{XUID: "1", IsFollowingCaller: true, IsFollowedByCaller: true}},
+	}
+	syncer := FriendSyncer{
+		Client:       client,
+		Config:       FriendSyncConfig{ExpiryEnabled: true, ExpiryDays: 15},
+		History:      history,
+		PruneHistory: true,
+	}
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := history.lastSeen["gone"]; ok {
+		t.Fatal("expected history entry for ex-friend to be pruned")
+	}
+	if _, ok := history.lastSeen["1"]; !ok {
+		t.Fatal("expected history entry for current friend to remain")
+	}
+}
+
+func TestFriendSyncRunStateTracksSeparateFollowAndUnfollowBackoff(t *testing.T) {
 	now := time.Unix(100, 0)
 	state := friendSyncRunState{}
-	state.recordError(now, &xblsocial.ResponseError{StatusCode: 429, RetryAfter: 2 * time.Minute})
+	state.record(now, friendSyncResult{followRetryAfter: 2 * time.Minute})
 
 	blocked := state.options(now.Add(time.Minute), true)
-	if blocked.autoFollow || blocked.autoUnfollow {
-		t.Fatalf("expected mutations suppressed during retry-after, got %#v", blocked)
+	if blocked.autoFollow {
+		t.Fatal("expected auto-follow suppressed during retry-after")
+	}
+	if !blocked.autoUnfollow {
+		t.Fatal("expected auto-unfollow to keep running (separate limit)")
 	}
 
 	allowed := state.options(now.Add(3*time.Minute), true)
@@ -209,24 +360,10 @@ func TestFriendSyncRunStateSuppressesMutationsDuringRetryAfter(t *testing.T) {
 	}
 }
 
-func TestFriendSyncRunStateSkipsReadsDuringRetryAfter(t *testing.T) {
-	now := time.Unix(100, 0)
-	state := friendSyncRunState{}
-	state.recordError(now, &xblsocial.ResponseError{StatusCode: 429, RetryAfter: 2 * time.Minute})
-
-	if !state.backingOff(now.Add(time.Minute)) {
-		t.Fatal("expected sync skipped during retry-after")
-	}
-
-	if state.backingOff(now.Add(3 * time.Minute)) {
-		t.Fatal("expected sync after retry-after")
-	}
-}
-
 func TestFriendSyncRunStateSuppressesAutoFollowWhenFriendListIsFull(t *testing.T) {
 	now := time.Unix(100, 0)
 	state := friendSyncRunState{}
-	state.recordError(now, &xblsocial.ResponseError{Code: 1028})
+	state.record(now, friendSyncResult{friendListFull: true})
 
 	opts := state.options(now.Add(time.Minute), true)
 	if opts.autoFollow {
@@ -238,12 +375,46 @@ func TestFriendSyncRunStateSuppressesAutoFollowWhenFriendListIsFull(t *testing.T
 }
 
 type syncFriendClient struct {
-	people      []Person
-	accept      func(context.Context) ([]Person, error)
-	follow      func(context.Context, string) error
-	unfollow    func(context.Context, string) error
-	followCalls int
-	removeCalls int
+	people          []Person
+	accept          func(context.Context) ([]Person, error)
+	follow          func(context.Context, string) error
+	unfollow        func(context.Context, string) error
+	followCalls     int
+	removeCalls     int
+	forceUnfollowed []string
+}
+
+func (c *syncFriendClient) ForceUnfollow(_ context.Context, xuid string) error {
+	c.forceUnfollowed = append(c.forceUnfollowed, xuid)
+	return nil
+}
+
+type notifierFunc func(context.Context, string) error
+
+func (f notifierFunc) Notify(ctx context.Context, message string) error {
+	return f(ctx, message)
+}
+
+type syncHistoryStore struct {
+	lastSeen map[string]time.Time
+}
+
+func (s *syncHistoryStore) LastSeen(_ context.Context, xuid string) (time.Time, bool, error) {
+	when, ok := s.lastSeen[xuid]
+	return when, ok, nil
+}
+
+func (s *syncHistoryStore) Clear(_ context.Context, xuid string) error {
+	delete(s.lastSeen, xuid)
+	return nil
+}
+
+func (s *syncHistoryStore) XUIDs(context.Context) ([]string, error) {
+	xuids := make([]string, 0, len(s.lastSeen))
+	for xuid := range s.lastSeen {
+		xuids = append(xuids, xuid)
+	}
+	return xuids, nil
 }
 
 func (c *syncFriendClient) Friends(context.Context) ([]Person, error) {

--- a/friends.go
+++ b/friends.go
@@ -1,19 +1,22 @@
 package broadcaster
 
 import (
+	"bytes"
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
-	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
-// FriendClient adapts go-xsapi/v2's Xbox social client to the FriendSyncer API.
+// FriendClient implements the Xbox social calls used by FriendSyncer with the
+// same endpoints, contract versions, and request shapes as MCXboxBroadcast.
 type FriendClient struct {
 	Client *http.Client
-	Social *xblsocial.Client
 }
 
 type Person struct {
@@ -25,6 +28,23 @@ type Person struct {
 	IsFollowedByCaller   bool   `json:"isFollowedByCaller"`
 	UniqueModernGamertag string `json:"uniqueModernGamertag"`
 }
+
+// SocialSummary is the caller's follower/following totals from the Xbox
+// social summary endpoint.
+type SocialSummary struct {
+	TargetFollowingCount int `json:"targetFollowingCount"`
+	TargetFollowerCount  int `json:"targetFollowerCount"`
+}
+
+const (
+	peopleHubFollowersURL = "https://peoplehub.xboxlive.com/users/me/people/followers"
+	peopleHubSocialURL    = "https://peoplehub.xboxlive.com/users/me/people/social"
+	pendingRequestsURL    = "https://peoplehub.xboxlive.com/users/me/people/friendrequests(received)"
+	bulkAddFriendsURL     = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
+	socialSummaryURL      = "https://social.xboxlive.com/users/me/summary"
+	peopleURLFormat       = "https://social.xboxlive.com/users/me/people/xuid(%s)"
+	followerURLFormat     = "https://social.xboxlive.com/users/me/people/follower/xuid(%s)"
+)
 
 // AcceptFriendRequestsError reports a successful bulk accept response that
 // still failed to update one or more pending friend requests.
@@ -41,48 +61,90 @@ func (e *AcceptFriendRequestsError) FailedXUIDs() []string {
 }
 
 // Friends returns a merged view of people following the authenticated account
-// and people the authenticated account follows.
+// and people the authenticated account follows. Both lists are fetched
+// undecorated with contract version 5, matching MCXboxBroadcast.
 func (c FriendClient) Friends(ctx context.Context) ([]Person, error) {
-	// go-xsapi/social.Friends only returns accepted friends; sync needs both
-	// sides of the relationship so pending inbound followers can be accepted.
-	socialClient := c.social()
-	followers, err := socialClient.Followers(ctx)
+	followers, err := c.people(ctx, peopleHubFollowersURL, "5")
 	if err != nil {
 		return nil, err
 	}
-	following, err := socialClient.Following(ctx)
+	following, err := c.people(ctx, peopleHubSocialURL, "5")
 	if err != nil {
 		return nil, err
 	}
-	return mergePeople(peopleFromSocialUsers(followers), peopleFromSocialUsers(following)), nil
+	return mergePeople(followers, following), nil
 }
 
-// AcceptPendingFriendRequests accepts incoming Xbox friend requests and returns
-// the people that Xbox reported as updated.
+// Summary returns the caller's social summary, including the total number of
+// people the account follows.
+func (c FriendClient) Summary(ctx context.Context) (SocialSummary, error) {
+	var summary SocialSummary
+	resp, err := c.do(ctx, http.MethodGet, socialSummaryURL, "3", nil)
+	if err != nil {
+		return SocialSummary{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return SocialSummary{}, socialResponseError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		return SocialSummary{}, err
+	}
+	return summary, nil
+}
+
+// AcceptPendingFriendRequests accepts incoming Xbox friend requests with a
+// single bulk add call and returns the people that Xbox reported as updated.
 func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person, error) {
-	socialClient := c.social()
-	pending, err := socialClient.IncomingFriendRequests(ctx)
+	pending, err := c.people(ctx, pendingRequestsURL, "7")
 	if err != nil {
 		return nil, err
 	}
-	if len(pending) == 0 {
+	xuids := make([]string, 0, len(pending))
+	byXUID := make(map[string]Person, len(pending))
+	for _, person := range pending {
+		if person.XUID == "" {
+			continue
+		}
+		xuids = append(xuids, person.XUID)
+		byXUID[person.XUID] = person
+	}
+	if len(xuids) == 0 {
 		return nil, nil
 	}
 
-	accepted := make([]Person, 0, len(pending))
+	body, err := json.Marshal(map[string][]string{"xuids": xuids})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(ctx, http.MethodPost, bulkAddFriendsURL, "1", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, socialResponseError(resp)
+	}
+	var result struct {
+		UpdatedPeople []string `json:"updatedPeople"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	updated := make(map[string]struct{}, len(result.UpdatedPeople))
+	accepted := make([]Person, 0, len(result.UpdatedPeople))
+	for _, xuid := range result.UpdatedPeople {
+		if person, ok := byXUID[xuid]; ok {
+			updated[xuid] = struct{}{}
+			accepted = append(accepted, person)
+		}
+	}
 	var failed []string
-	for _, user := range pending {
-		if user.XUID == "" {
-			continue
+	for _, xuid := range xuids {
+		if _, ok := updated[xuid]; !ok {
+			failed = append(failed, xuid)
 		}
-		if err := socialClient.AddFriend(ctx, user.XUID); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || retryDelay(err) > 0 {
-				return accepted, err
-			}
-			failed = append(failed, user.XUID)
-			continue
-		}
-		accepted = append(accepted, personFromSocialUser(user))
 	}
 	if len(failed) > 0 {
 		return accepted, &AcceptFriendRequestsError{Failed: failed}
@@ -90,30 +152,114 @@ func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person
 	return accepted, nil
 }
 
-func (c FriendClient) social() *xblsocial.Client {
-	if c.Social != nil {
-		return c.Social
-	}
-	return xblsocial.New(c.client(), nil, xsts.UserInfo{}, nil)
-}
-
 // Follow follows the XUID, which makes the user a friend when they also follow
 // the authenticated account.
 func (c FriendClient) Follow(ctx context.Context, xuid string) error {
-	return c.social().Follow(ctx, xuid)
+	return c.relationship(ctx, http.MethodPut, fmt.Sprintf(peopleURLFormat, xuid), http.StatusOK, http.StatusNoContent)
 }
 
 // Unfollow removes the authenticated account's follow relationship for xuid.
 func (c FriendClient) Unfollow(ctx context.Context, xuid string) error {
-	return c.social().Unfollow(ctx, xuid)
+	return c.relationship(ctx, http.MethodDelete, fmt.Sprintf(peopleURLFormat, xuid), http.StatusOK, http.StatusNoContent)
 }
 
-func peopleFromSocialUsers(users []xblsocial.User) []Person {
-	people := make([]Person, 0, len(users))
-	for _, user := range users {
-		people = append(people, personFromSocialUser(user))
+// ForceUnfollow removes the follow relationship the user identified by xuid
+// has towards the authenticated account. It is used to drop followers whose
+// privacy or enforcement restrictions prevent a friendship.
+func (c FriendClient) ForceUnfollow(ctx context.Context, xuid string) error {
+	return c.relationship(ctx, http.MethodDelete, fmt.Sprintf(followerURLFormat, xuid), http.StatusOK, http.StatusNoContent)
+}
+
+// relationship sends a relationship mutation and converts non-success
+// responses into social response errors.
+func (c FriendClient) relationship(ctx context.Context, method, url string, successCodes ...int) error {
+	resp, err := c.do(ctx, method, url, "3", nil)
+	if err != nil {
+		return err
 	}
-	return people
+	defer resp.Body.Close()
+	for _, code := range successCodes {
+		if resp.StatusCode == code {
+			return nil
+		}
+	}
+	return socialResponseError(resp)
+}
+
+// people fetches a PeopleHub or social people list.
+func (c FriendClient) people(ctx context.Context, url, contractVersion string) ([]Person, error) {
+	resp, err := c.do(ctx, http.MethodGet, url, contractVersion, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, socialResponseError(resp)
+	}
+	var result struct {
+		People []Person `json:"people"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return result.People, nil
+}
+
+func (c FriendClient) do(ctx context.Context, method, url, contractVersion string, body io.Reader) (*http.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Xbl-Contract-Version", contractVersion)
+	req.Header.Set("Accept-Language", "en-GB")
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.client().Do(req)
+}
+
+// socialResponseError converts a non-success social/PeopleHub response into an
+// *xblsocial.ResponseError so callers can match rate limits and restriction
+// codes with errors.Is/As.
+func socialResponseError(resp *http.Response) error {
+	responseErr := &xblsocial.ResponseError{
+		StatusCode: resp.StatusCode,
+		RetryAfter: retryAfterHeader(resp.Header.Get("Retry-After")),
+	}
+	if resp.Request != nil {
+		responseErr.Method = resp.Request.Method
+		if resp.Request.URL != nil {
+			responseErr.URL = resp.Request.URL.String()
+		}
+	}
+	var body struct {
+		Code        int    `json:"code"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err == nil {
+		responseErr.Code = body.Code
+		responseErr.Description = body.Description
+	}
+	return responseErr
+}
+
+func retryAfterHeader(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
 }
 
 func mergePeople(groups ...[]Person) []Person {
@@ -156,18 +302,6 @@ func mergePerson(existing, next Person) Person {
 		existing.UniqueModernGamertag = next.UniqueModernGamertag
 	}
 	return existing
-}
-
-func personFromSocialUser(user xblsocial.User) Person {
-	return Person{
-		XUID:                 user.XUID,
-		Gamertag:             user.GamerTag,
-		DisplayName:          user.DisplayName,
-		ModernGamertag:       user.ModernGamerTag,
-		IsFollowingCaller:    user.Followed,
-		IsFollowedByCaller:   user.Following,
-		UniqueModernGamertag: user.UniqueModernGamerTag,
-	}
 }
 
 func (c FriendClient) client() *http.Client {

--- a/friends.go
+++ b/friends.go
@@ -1,22 +1,20 @@
 package broadcaster
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"strconv"
-	"time"
 
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
-// FriendClient implements the Xbox social calls used by FriendSyncer with the
-// same endpoints, contract versions, and request shapes as MCXboxBroadcast.
+// FriendClient adapts go-xsapi/v2's Xbox social client to the FriendSyncer
+// API, using the same endpoints, contract versions, and request shapes as
+// MCXboxBroadcast.
 type FriendClient struct {
 	Client *http.Client
+	Social *xblsocial.Client
 }
 
 type Person struct {
@@ -29,22 +27,9 @@ type Person struct {
 	UniqueModernGamertag string `json:"uniqueModernGamertag"`
 }
 
-// SocialSummary is the caller's follower/following totals from the Xbox
-// social summary endpoint.
-type SocialSummary struct {
-	TargetFollowingCount int `json:"targetFollowingCount"`
-	TargetFollowerCount  int `json:"targetFollowerCount"`
-}
-
-const (
-	peopleHubFollowersURL = "https://peoplehub.xboxlive.com/users/me/people/followers"
-	peopleHubSocialURL    = "https://peoplehub.xboxlive.com/users/me/people/social"
-	pendingRequestsURL    = "https://peoplehub.xboxlive.com/users/me/people/friendrequests(received)"
-	bulkAddFriendsURL     = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
-	socialSummaryURL      = "https://social.xboxlive.com/users/me/summary"
-	peopleURLFormat       = "https://social.xboxlive.com/users/me/people/xuid(%s)"
-	followerURLFormat     = "https://social.xboxlive.com/users/me/people/follower/xuid(%s)"
-)
+// friendListConfig fetches people lists undecorated with contract version 5,
+// keeping the periodic response small at large friend counts.
+var friendListConfig = xblsocial.PeopleListConfig{Undecorated: true, ContractVersion: 5}
 
 // AcceptFriendRequestsError reports a successful bulk accept response that
 // still failed to update one or more pending friend requests.
@@ -61,80 +46,54 @@ func (e *AcceptFriendRequestsError) FailedXUIDs() []string {
 }
 
 // Friends returns a merged view of people following the authenticated account
-// and people the authenticated account follows. Both lists are fetched
-// undecorated with contract version 5, matching MCXboxBroadcast.
+// and people the authenticated account follows.
 func (c FriendClient) Friends(ctx context.Context) ([]Person, error) {
-	followers, err := c.people(ctx, peopleHubFollowersURL, "5")
+	socialClient := c.social()
+	followers, err := socialClient.People(ctx, xblsocial.PeopleListFollowers, friendListConfig)
 	if err != nil {
 		return nil, err
 	}
-	following, err := c.people(ctx, peopleHubSocialURL, "5")
+	following, err := socialClient.People(ctx, xblsocial.PeopleListFollowing, friendListConfig)
 	if err != nil {
 		return nil, err
 	}
-	return mergePeople(followers, following), nil
+	return mergePeople(peopleFromSocialUsers(followers), peopleFromSocialUsers(following)), nil
 }
 
 // Summary returns the caller's social summary, including the total number of
 // people the account follows.
-func (c FriendClient) Summary(ctx context.Context) (SocialSummary, error) {
-	var summary SocialSummary
-	resp, err := c.do(ctx, http.MethodGet, socialSummaryURL, "3", nil)
-	if err != nil {
-		return SocialSummary{}, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return SocialSummary{}, socialResponseError(resp)
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
-		return SocialSummary{}, err
-	}
-	return summary, nil
+func (c FriendClient) Summary(ctx context.Context) (xblsocial.Summary, error) {
+	return c.social().Summary(ctx)
 }
 
 // AcceptPendingFriendRequests accepts incoming Xbox friend requests with a
 // single bulk add call and returns the people that Xbox reported as updated.
 func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person, error) {
-	pending, err := c.people(ctx, pendingRequestsURL, "7")
+	socialClient := c.social()
+	pending, err := socialClient.People(ctx, xblsocial.PeopleListIncomingFriendRequests, xblsocial.PeopleListConfig{Undecorated: true})
 	if err != nil {
 		return nil, err
 	}
 	xuids := make([]string, 0, len(pending))
 	byXUID := make(map[string]Person, len(pending))
-	for _, person := range pending {
-		if person.XUID == "" {
+	for _, user := range pending {
+		if user.XUID == "" {
 			continue
 		}
-		xuids = append(xuids, person.XUID)
-		byXUID[person.XUID] = person
+		xuids = append(xuids, user.XUID)
+		byXUID[user.XUID] = personFromSocialUser(user)
 	}
 	if len(xuids) == 0 {
 		return nil, nil
 	}
 
-	body, err := json.Marshal(map[string][]string{"xuids": xuids})
+	updatedXUIDs, err := socialClient.BulkAddFriends(ctx, xuids)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.do(ctx, http.MethodPost, bulkAddFriendsURL, "1", bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, socialResponseError(resp)
-	}
-	var result struct {
-		UpdatedPeople []string `json:"updatedPeople"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
-	}
-
-	updated := make(map[string]struct{}, len(result.UpdatedPeople))
-	accepted := make([]Person, 0, len(result.UpdatedPeople))
-	for _, xuid := range result.UpdatedPeople {
+	updated := make(map[string]struct{}, len(updatedXUIDs))
+	accepted := make([]Person, 0, len(updatedXUIDs))
+	for _, xuid := range updatedXUIDs {
 		if person, ok := byXUID[xuid]; ok {
 			updated[xuid] = struct{}{}
 			accepted = append(accepted, person)
@@ -155,111 +114,46 @@ func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person
 // Follow follows the XUID, which makes the user a friend when they also follow
 // the authenticated account.
 func (c FriendClient) Follow(ctx context.Context, xuid string) error {
-	return c.relationship(ctx, http.MethodPut, fmt.Sprintf(peopleURLFormat, xuid), http.StatusOK, http.StatusNoContent)
+	return c.social().Follow(ctx, xuid)
 }
 
 // Unfollow removes the authenticated account's follow relationship for xuid.
 func (c FriendClient) Unfollow(ctx context.Context, xuid string) error {
-	return c.relationship(ctx, http.MethodDelete, fmt.Sprintf(peopleURLFormat, xuid), http.StatusOK, http.StatusNoContent)
+	return c.social().Unfollow(ctx, xuid)
 }
 
 // ForceUnfollow removes the follow relationship the user identified by xuid
 // has towards the authenticated account. It is used to drop followers whose
 // privacy or enforcement restrictions prevent a friendship.
 func (c FriendClient) ForceUnfollow(ctx context.Context, xuid string) error {
-	return c.relationship(ctx, http.MethodDelete, fmt.Sprintf(followerURLFormat, xuid), http.StatusOK, http.StatusNoContent)
+	return c.social().RemoveFollower(ctx, xuid)
 }
 
-// relationship sends a relationship mutation and converts non-success
-// responses into social response errors.
-func (c FriendClient) relationship(ctx context.Context, method, url string, successCodes ...int) error {
-	resp, err := c.do(ctx, method, url, "3", nil)
-	if err != nil {
-		return err
+func (c FriendClient) social() *xblsocial.Client {
+	if c.Social != nil {
+		return c.Social
 	}
-	defer resp.Body.Close()
-	for _, code := range successCodes {
-		if resp.StatusCode == code {
-			return nil
-		}
-	}
-	return socialResponseError(resp)
+	return xblsocial.New(c.client(), nil, xsts.UserInfo{}, nil)
 }
 
-// people fetches a PeopleHub or social people list.
-func (c FriendClient) people(ctx context.Context, url, contractVersion string) ([]Person, error) {
-	resp, err := c.do(ctx, http.MethodGet, url, contractVersion, nil)
-	if err != nil {
-		return nil, err
+func peopleFromSocialUsers(users []xblsocial.User) []Person {
+	people := make([]Person, 0, len(users))
+	for _, user := range users {
+		people = append(people, personFromSocialUser(user))
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, socialResponseError(resp)
-	}
-	var result struct {
-		People []Person `json:"people"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
-	}
-	return result.People, nil
+	return people
 }
 
-func (c FriendClient) do(ctx context.Context, method, url, contractVersion string, body io.Reader) (*http.Response, error) {
-	if ctx == nil {
-		ctx = context.Background()
+func personFromSocialUser(user xblsocial.User) Person {
+	return Person{
+		XUID:                 user.XUID,
+		Gamertag:             user.GamerTag,
+		DisplayName:          user.DisplayName,
+		ModernGamertag:       user.ModernGamerTag,
+		IsFollowingCaller:    user.Followed,
+		IsFollowedByCaller:   user.Following,
+		UniqueModernGamertag: user.UniqueModernGamerTag,
 	}
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("X-Xbl-Contract-Version", contractVersion)
-	req.Header.Set("Accept-Language", "en-GB")
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return c.client().Do(req)
-}
-
-// socialResponseError converts a non-success social/PeopleHub response into an
-// *xblsocial.ResponseError so callers can match rate limits and restriction
-// codes with errors.Is/As.
-func socialResponseError(resp *http.Response) error {
-	responseErr := &xblsocial.ResponseError{
-		StatusCode: resp.StatusCode,
-		RetryAfter: retryAfterHeader(resp.Header.Get("Retry-After")),
-	}
-	if resp.Request != nil {
-		responseErr.Method = resp.Request.Method
-		if resp.Request.URL != nil {
-			responseErr.URL = resp.Request.URL.String()
-		}
-	}
-	var body struct {
-		Code        int    `json:"code"`
-		Description string `json:"description"`
-	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err == nil {
-		responseErr.Code = body.Code
-		responseErr.Description = body.Description
-	}
-	return responseErr
-}
-
-func retryAfterHeader(value string) time.Duration {
-	if value == "" {
-		return 0
-	}
-	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
-		return time.Duration(seconds) * time.Second
-	}
-	if when, err := http.ParseTime(value); err == nil {
-		if delay := time.Until(when); delay > 0 {
-			return delay
-		}
-	}
-	return 0
 }
 
 func mergePeople(groups ...[]Person) []Person {

--- a/friends_test.go
+++ b/friends_test.go
@@ -11,25 +11,10 @@ import (
 	"time"
 
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
-	"golang.org/x/oauth2"
 )
-
-const socialDecorations = "bio,detail,multiplayerSummary,preferredColor,presenceDetail"
-
-func peopleHubURL(group string) string {
-	return "https://peoplehub.xboxlive.com/users/me/people/" + group + "/decoration/" + socialDecorations
-}
 
 func followURL(xuid string) string {
 	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/xuid(%s)", xuid)
-}
-
-func addFriendURL(xuid string) string {
-	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/friends/v2/xuid(%s)", xuid)
-}
-
-func unfollowURL(xuid string) string {
-	return addFriendURL(xuid) + "?deleteRelationships=follows"
 }
 
 func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
@@ -38,12 +23,14 @@ func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			requests = append(requests, req.URL.String())
 			switch req.URL.String() {
-			case peopleHubURL("followers"):
-				if req.Header.Get("X-Xbl-Contract-Version") != "7" {
-					t.Fatalf("contract version = %q, want 7", req.Header.Get("X-Xbl-Contract-Version"))
+			case peopleHubFollowersURL:
+				// Undecorated contract 5 matches MCXboxBroadcast and keeps
+				// the periodic response small at large friend counts.
+				if req.Header.Get("X-Xbl-Contract-Version") != "5" {
+					t.Fatalf("contract version = %q, want 5", req.Header.Get("X-Xbl-Contract-Version"))
 				}
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"Follower","displayName":"Display","modernGamertag":"Modern","uniqueModernGamertag":"Modern#1234","isFollowingCaller":true}]}`), nil
-			case peopleHubURL("social"):
+			case peopleHubSocialURL:
 				return response(http.StatusOK, `{"people":[{"xuid":"1","isFollowedByCaller":true},{"xuid":"2","gamertag":"Followed","isFollowedByCaller":true}]}`), nil
 			default:
 				t.Fatalf("unexpected URL %s", req.URL)
@@ -55,7 +42,7 @@ func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantRequests := strings.Join([]string{peopleHubURL("followers"), peopleHubURL("social")}, ",")
+	wantRequests := strings.Join([]string{peopleHubFollowersURL, peopleHubSocialURL}, ",")
 	if got := strings.Join(requests, ","); got != wantRequests {
 		t.Fatalf("requests = %s, want %s", got, wantRequests)
 	}
@@ -128,7 +115,7 @@ func TestFriendClientUnfollowReturnsRetryAfterError(t *testing.T) {
 			if req.Method != http.MethodDelete {
 				t.Fatalf("unexpected method %s", req.Method)
 			}
-			if req.URL.String() != unfollowURL("123") {
+			if req.URL.String() != followURL("123") {
 				t.Fatalf("unexpected URL %s", req.URL)
 			}
 			resp := response(http.StatusTooManyRequests, "")
@@ -200,7 +187,7 @@ func TestFriendClientFollowReturnsSocialResponseErrors(t *testing.T) {
 	}
 }
 
-func TestFriendClientAcceptPendingFriendRequests(t *testing.T) {
+func TestFriendClientAcceptPendingFriendRequestsUsesBulkAdd(t *testing.T) {
 	var requests []string
 	client := FriendClient{
 		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -209,62 +196,36 @@ func TestFriendClientAcceptPendingFriendRequests(t *testing.T) {
 				t.Fatal("missing authorization header")
 			}
 			switch {
-			case req.Method == http.MethodGet && req.URL.String() == peopleHubURL("friendRequests(received)"):
+			case req.Method == http.MethodGet && req.URL.String() == pendingRequestsURL:
 				if req.Header.Get("X-Xbl-Contract-Version") != "7" {
 					t.Fatalf("contract version = %q, want 7", req.Header.Get("X-Xbl-Contract-Version"))
 				}
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"},{"xuid":"2","gamertag":"Two"}]}`), nil
-			case req.Method == http.MethodPut && req.URL.String() == addFriendURL("1"):
-				return response(http.StatusOK, ""), nil
-			case req.Method == http.MethodPut && req.URL.String() == addFriendURL("2"):
-				return response(http.StatusOK, ""), nil
+			case req.Method == http.MethodPost && req.URL.String() == bulkAddFriendsURL:
+				body, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if want := `{"xuids":["1","2"]}`; string(body) != want {
+					t.Fatalf("bulk body = %s, want %s", body, want)
+				}
+				return response(http.StatusOK, `{"updatedPeople":["1","2"]}`), nil
 			default:
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
 		})),
 	}
-	accepter, ok := any(client).(interface {
-		AcceptPendingFriendRequests(context.Context) ([]Person, error)
-	})
-	if !ok {
-		t.Fatal("FriendClient does not accept pending friend requests")
-	}
-	accepted, err := accepter.AcceptPendingFriendRequests(context.Background())
+	accepted, err := client.AcceptPendingFriendRequests(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 	wantRequests := strings.Join([]string{
-		http.MethodGet + " " + peopleHubURL("friendRequests(received)"),
-		http.MethodPut + " " + addFriendURL("1"),
-		http.MethodPut + " " + addFriendURL("2"),
+		http.MethodGet + " " + pendingRequestsURL,
+		http.MethodPost + " " + bulkAddFriendsURL,
 	}, ",")
 	if got := strings.Join(requests, ","); got != wantRequests {
 		t.Fatalf("requests = %s, want %s", got, wantRequests)
-	}
-	if len(accepted) != 2 || accepted[0].XUID != "1" || accepted[1].XUID != "2" {
-		t.Fatalf("accepted people = %#v", accepted)
-	}
-}
-
-func TestFriendClientAcceptPendingFriendRequestsReturnsAcceptedPeople(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			switch req.Method {
-			case http.MethodGet:
-				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"},{"xuid":"2","gamertag":"Two"}]}`), nil
-			case http.MethodPut:
-				return response(http.StatusOK, ""), nil
-			default:
-				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
-			}
-			return nil, nil
-		})},
-	}
-
-	accepted, err := client.AcceptPendingFriendRequests(context.Background())
-	if err != nil {
-		t.Fatal(err)
 	}
 	if len(accepted) != 2 || accepted[0].XUID != "1" || accepted[1].XUID != "2" {
 		t.Fatalf("accepted people = %#v", accepted)
@@ -277,7 +238,7 @@ func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testin
 			switch req.Method {
 			case http.MethodGet:
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"}]}`), nil
-			case http.MethodPut:
+			case http.MethodPost:
 				resp := response(http.StatusTooManyRequests, "")
 				resp.Header.Set("Retry-After", "11")
 				return resp, nil
@@ -287,13 +248,7 @@ func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testin
 			return nil, nil
 		})},
 	}
-	accepter, ok := any(client).(interface {
-		AcceptPendingFriendRequests(context.Context) ([]Person, error)
-	})
-	if !ok {
-		t.Fatal("FriendClient does not accept pending friend requests")
-	}
-	_, err := accepter.AcceptPendingFriendRequests(context.Background())
+	_, err := client.AcceptPendingFriendRequests(context.Background())
 	if err == nil {
 		t.Fatal("expected retry-after error")
 	}
@@ -309,13 +264,11 @@ func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testin
 func TestFriendClientAcceptPendingFriendRequestsReportsFailedUpdates(t *testing.T) {
 	client := FriendClient{
 		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			switch {
-			case req.Method == http.MethodGet:
+			switch req.Method {
+			case http.MethodGet:
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"},{"xuid":"2","gamertag":"Two"}]}`), nil
-			case req.Method == http.MethodPut && req.URL.String() == addFriendURL("1"):
-				return response(http.StatusOK, ""), nil
-			case req.Method == http.MethodPut && req.URL.String() == addFriendURL("2"):
-				return response(http.StatusBadRequest, `{"code":1049,"description":"restricted"}`), nil
+			case http.MethodPost:
+				return response(http.StatusOK, `{"updatedPeople":["1"]}`), nil
 			default:
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
@@ -338,6 +291,46 @@ func TestFriendClientAcceptPendingFriendRequestsReportsFailedUpdates(t *testing.
 	}
 	if got := strings.Join(acceptErr.FailedXUIDs(), ","); got != "2" {
 		t.Fatalf("failed xuids = %s, want 2", got)
+	}
+}
+
+func TestFriendClientForceUnfollowDeletesFollowerRelationship(t *testing.T) {
+	called := false
+	client := FriendClient{
+		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			if req.Method != http.MethodDelete {
+				t.Fatalf("unexpected method %s", req.Method)
+			}
+			if want := "https://social.xboxlive.com/users/me/people/follower/xuid(123)"; req.URL.String() != want {
+				t.Fatalf("unexpected URL %s, want %s", req.URL, want)
+			}
+			return response(http.StatusNoContent, ""), nil
+		})},
+	}
+	if err := client.ForceUnfollow(context.Background(), "123"); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("client was not called")
+	}
+}
+
+func TestFriendClientSummaryReturnsFollowingCount(t *testing.T) {
+	client := FriendClient{
+		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != socialSummaryURL {
+				t.Fatalf("unexpected URL %s", req.URL)
+			}
+			return response(http.StatusOK, `{"targetFollowingCount":1337,"targetFollowerCount":42}`), nil
+		})},
+	}
+	summary, err := client.Summary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.TargetFollowingCount != 1337 || summary.TargetFollowerCount != 42 {
+		t.Fatalf("summary = %#v", summary)
 	}
 }
 
@@ -369,10 +362,4 @@ func response(code int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     make(http.Header),
 	}
-}
-
-type staticOAuthSource struct{}
-
-func (staticOAuthSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{AccessToken: "live"}, nil
 }

--- a/friends_test.go
+++ b/friends_test.go
@@ -13,6 +13,16 @@ import (
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
 )
 
+// Endpoint fixtures pinning the exact request URLs the social layer must hit
+// for MCXboxBroadcast parity.
+const (
+	peopleHubFollowersURL = "https://peoplehub.xboxlive.com/users/me/people/followers"
+	peopleHubSocialURL    = "https://peoplehub.xboxlive.com/users/me/people/social"
+	pendingRequestsURL    = "https://peoplehub.xboxlive.com/users/me/people/friendRequests(received)"
+	bulkAddFriendsURL     = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
+	socialSummaryURL      = "https://social.xboxlive.com/users/me/summary"
+)
+
 func followURL(xuid string) string {
 	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/xuid(%s)", xuid)
 }

--- a/gallery.go
+++ b/gallery.go
@@ -16,7 +16,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/sandertv/gophertunnel/minecraft/service"
 )
@@ -152,7 +151,8 @@ func (g GalleryClient) Upload(ctx context.Context, imagePath string, featured bo
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("X-Ms-Showcased-Featured", fmt.Sprint(featured))
 	if stat, err := f.Stat(); err == nil {
-		req.Header.Set("X-Ms-Showcased-Timetaken", stat.ModTime().Format(time.RFC3339))
+		// UTC with milliseconds, matching Java's Instant.toString().
+		req.Header.Set("X-Ms-Showcased-Timetaken", stat.ModTime().UTC().Format("2006-01-02T15:04:05.000Z"))
 	}
 	resp, err := g.client().Do(req)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -54,4 +54,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260701052017-789939bda684
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260701032655-457547c73e9f
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026

--- a/go.mod
+++ b/go.mod
@@ -54,4 +54,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260701052017-789939bda684
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702001352-c1f30a18056e

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026 h1:WVKIu2CbiPr+hLkUrmQTrcO2rivXqWf5gwDMCK4G/B4=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702001352-c1f30a18056e h1:B524y66RyrNKJ4PSUrS7GU3p6KGTta+d9Mf5EnRtPuo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702001352-c1f30a18056e/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260701032655-457547c73e9f h1:FaJ6ESCtql77tz/vn8woOk+9O3o0tM2tOy4V4PEBiq4=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260701032655-457547c73e9f/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026 h1:WVKIu2CbiPr+hLkUrmQTrcO2rivXqWf5gwDMCK4G/B4=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702000623-6a8909e34026/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/integration_clients_test.go
+++ b/integration_clients_test.go
@@ -87,7 +87,9 @@ func TestSlackNotifierErrorDoesNotLeakWebhookURL(t *testing.T) {
 	}
 }
 
-func TestSessionUpdateFailureNotificationCanBeSuppressed(t *testing.T) {
+func TestSessionUpdateFailureNotificationIgnoresSuppressFlag(t *testing.T) {
+	// Matching MCXboxBroadcast, suppressSessionUpdateMessage only demotes the
+	// periodic success log; failure notifications always fire.
 	var notified bool
 	b := &Broadcaster{
 		conf: Config{
@@ -98,8 +100,8 @@ func TestSessionUpdateFailureNotificationCanBeSuppressed(t *testing.T) {
 		},
 	}
 	b.notifySessionUpdateFailure(context.Background(), errors.New("boom"))
-	if notified {
-		t.Fatal("session update notification was not suppressed")
+	if !notified {
+		t.Fatal("session update failure notification should not be suppressed")
 	}
 }
 
@@ -314,11 +316,10 @@ func TestFileHistoryStoreRecordsAndClearsLastSeen(t *testing.T) {
 
 func TestStatusUsesConfiguredProvider(t *testing.T) {
 	b, err := New(Config{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
-		XUID:            "123",
-		Server:          ServerInfo{Host: "127.0.0.1", Port: 19132},
-		StatusProvider:  staticStatusProvider{host: "Provider Host", world: "Provider World", titleID: TitleID},
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
+		StatusProvider: staticStatusProvider{host: "Provider Host", world: "Provider World", titleID: TitleID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -668,7 +669,14 @@ func TestStartCleansUpWhenPrimaryAnnounceFails(t *testing.T) {
 		conf: Config{
 			Server:    ServerInfo{Host: "127.0.0.1", Port: 19132},
 			Signaling: sig,
-			Status:    Status{HostName: "Host", WorldName: "World"},
+			StatusProvider: room.NewStatusProvider(room.Status{
+				HostName:  "Host",
+				WorldName: "World",
+				SupportedConnections: []room.Connection{{
+					ConnectionType: p2p.ConnectionTypeSignalingOverWebSocket,
+					NetherNetID:    p2p.NetherNetID("123"),
+				}},
+			}),
 		},
 		announcerFactory: func(*Broadcaster) room.Announcer {
 			return announcer
@@ -680,6 +688,27 @@ func TestStartCleansUpWhenPrimaryAnnounceFails(t *testing.T) {
 	}
 	if !announcer.Closed() {
 		t.Fatal("announcer was not closed")
+	}
+	if !sig.closed {
+		t.Fatal("signaling was not closed")
+	}
+}
+
+func TestStartFailsWhenSessionWouldPublishNoConnections(t *testing.T) {
+	sig := &fakeSignaling{}
+	b := &Broadcaster{
+		conf: Config{
+			Server:    ServerInfo{Host: "127.0.0.1", Port: 19132},
+			Signaling: sig,
+			Status:    Status{HostName: "Host", WorldName: "World"},
+		},
+		announcerFactory: func(*Broadcaster) room.Announcer {
+			return &fakeAnnouncer{}
+		},
+	}
+	err := b.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "unjoinable") {
+		t.Fatalf("Start() error = %v, want unjoinable session error", err)
 	}
 	if !sig.closed {
 		t.Fatal("signaling was not closed")

--- a/player_history.go
+++ b/player_history.go
@@ -53,6 +53,25 @@ func (s *FileHistoryStore) Seen(ctx context.Context, xuid string, when time.Time
 	return s.save(history)
 }
 
+// XUIDs returns every XUID with a recorded last-seen time.
+func (s *FileHistoryStore) XUIDs(ctx context.Context) ([]string, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	history, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	xuids := make([]string, 0, len(history))
+	for xuid := range history {
+		xuids = append(xuids, xuid)
+	}
+	return xuids, nil
+}
+
 func (s *FileHistoryStore) Clear(ctx context.Context, xuid string) error {
 	if err := ctxErr(ctx); err != nil {
 		return err

--- a/session_nonce_announcer.go
+++ b/session_nonce_announcer.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -274,15 +275,62 @@ func generateSessionNonce() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
+// statusWithNonces shadows room.Status fields whose wire shape diverges from
+// MCXboxBroadcast: isHardcore is added (Java always sends false) and
+// SupportedConnections re-encodes NetherNetId as a JSON number.
 type statusWithNonces struct {
 	room.Status
-	Nonces map[string]string `json:"nonces"`
+	IsHardcore           bool                `json:"isHardcore"`
+	SupportedConnections []sessionConnection `json:"SupportedConnections"`
+	Nonces               map[string]string   `json:"nonces"`
+}
+
+// sessionConnection mirrors room.Connection with a numeric NetherNetId,
+// matching the Java session document.
+type sessionConnection struct {
+	ConnectionType int             `json:"ConnectionType"`
+	HostIPAddress  string          `json:"HostIpAddress"`
+	HostPort       uint16          `json:"HostPort"`
+	NetherNetID    json.RawMessage `json:"NetherNetId"`
+	RakNetGUID     string          `json:"RakNetGUID,omitempty"`
+	PmsgID         uuid.UUID       `json:"PmsgId,omitempty"`
+}
+
+func sessionConnections(connections []room.Connection) []sessionConnection {
+	out := make([]sessionConnection, 0, len(connections))
+	for _, connection := range connections {
+		out = append(out, sessionConnection{
+			ConnectionType: connection.ConnectionType,
+			HostIPAddress:  connection.HostIPAddress,
+			HostPort:       connection.HostPort,
+			NetherNetID:    netherNetIDValue(connection.NetherNetID),
+			RakNetGUID:     connection.RakNetGUID,
+			PmsgID:         connection.PmsgID,
+		})
+	}
+	return out
+}
+
+// netherNetIDValue encodes a NetherNet ID as a JSON number when it is one,
+// falling back to a string for non-numeric values.
+func netherNetIDValue(id p2p.NetherNetID) json.RawMessage {
+	if _, err := strconv.ParseUint(string(id), 10, 64); err == nil {
+		return json.RawMessage(id)
+	}
+	quoted, err := json.Marshal(string(id))
+	if err != nil {
+		return json.RawMessage(`"0"`)
+	}
+	return quoted
 }
 
 func marshalStatusWithNonces(status room.Status, nonces map[string]string) ([]byte, error) {
+	connections := sessionConnections(status.SupportedConnections)
+	status.SupportedConnections = nil
 	return json.Marshal(statusWithNonces{
-		Status: status,
-		Nonces: copyStringMap(nonces),
+		Status:               status,
+		SupportedConnections: connections,
+		Nonces:               copyStringMap(nonces),
 	})
 }
 

--- a/session_nonce_announcer_test.go
+++ b/session_nonce_announcer_test.go
@@ -58,6 +58,35 @@ func TestMarshalStatusWithNoncesIncludesJavaSessionFields(t *testing.T) {
 	if connection["PmsgId"] != pmsgID.String() {
 		t.Fatalf("unexpected pmsg id: %#v", connection)
 	}
+	// Java serializes NetherNetId as a number and always sends isHardcore.
+	if connection["NetherNetId"] != float64(123456789) {
+		t.Fatalf("NetherNetId should be a JSON number: %#v", connection)
+	}
+	hardcore, ok := got["isHardcore"].(bool)
+	if !ok || hardcore {
+		t.Fatalf("isHardcore missing or true in custom properties: %s", custom)
+	}
+}
+
+func TestMarshalStatusWithNoncesKeepsOpaqueNetherNetIDAsString(t *testing.T) {
+	custom, err := marshalStatusWithNonces(room.Status{
+		WorldName: "World",
+		SupportedConnections: []room.Connection{{
+			NetherNetID: p2p.NetherNetID("opaque-id"),
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		SupportedConnections []map[string]any `json:"SupportedConnections"`
+	}
+	if err := json.Unmarshal(custom, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SupportedConnections[0]["NetherNetId"] != "opaque-id" {
+		t.Fatalf("opaque NetherNetId should stay a string: %s", custom)
+	}
 }
 
 func TestMarshalStatusWithNoncesWritesEmptyObject(t *testing.T) {

--- a/signaling_connection.go
+++ b/signaling_connection.go
@@ -20,8 +20,9 @@ type signalingConnectionAnnouncer struct {
 }
 
 func (a signalingConnectionAnnouncer) Announce(ctx context.Context, status room.Status) error {
-	// TODO: Remove this override once we use lac's p2p support for publishing
-	// JSON-RPC NetherNet connection metadata directly.
+	// The session document must advertise exactly the JSON-RPC signaling
+	// connection clients can join through; any caller-provided connections are
+	// deliberately replaced, matching MCXboxBroadcast's single-connection doc.
 	status.SupportedConnections = []room.Connection{a.connection}
 	return a.Announcer.Announce(ctx, status)
 }

--- a/status.go
+++ b/status.go
@@ -43,24 +43,25 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 				"players", queried.PlayerCount,
 				"max_players", queried.MaxPlayers,
 			)
-			st.WorldName = queried.ServerName
-			st.HostName = queried.ServerSubName
-			st.Players = queried.PlayerCount
-			st.MaxPlayers = queried.MaxPlayers
-		} else if !st.QueryFallback {
-			return room.Status{}, err
+			b.lastQuery = &queried
+			applyQueriedStatus(&st, queried)
+		} else if !st.QueryFallback && b.lastQuery != nil {
+			// Keep the last successful query result instead of failing the
+			// whole update; configFallback: true resets to configured values.
+			b.debug("target server status query failed; keeping last successful query result", "err", err)
+			applyQueriedStatus(&st, *b.lastQuery)
 		} else {
 			b.debug("target server status query failed; using configured status fallback", "err", err)
 		}
 	}
 
 	return normalizeStatus(room.Status{
-		HostName:                stripColour(defaultString(st.HostName, "MCXboxBroadcast")),
-		WorldName:               stripColour(defaultString(st.WorldName, defaultString(st.HostName, "MCXboxBroadcast"))),
+		HostName:                stripColour(defaultString(st.HostName, b.hostNameFallback())),
+		WorldName:               stripColour(defaultString(st.WorldName, defaultString(st.HostName, b.hostNameFallback()))),
 		OwnerID:                 ownerID,
-		WorldType:               defaultString(st.WorldType, room.WorldTypeCreative),
-		MemberCount:             max(st.Players, 1),
-		MaxMemberCount:          max(st.MaxPlayers, max(st.Players, 1)+1),
+		WorldType:               defaultString(st.WorldType, WorldTypeSurvival),
+		MemberCount:             max(st.Players, 0),
+		MaxMemberCount:          max(st.MaxPlayers, max(st.Players, 0)+1),
 		BroadcastSetting:        defaultBroadcastSetting(p2p.BroadcastSetting(st.Broadcast), p2p.BroadcastSettingFriendsOfFriends),
 		Joinability:             defaultString(st.Joinability, p2p.JoinabilityFriends),
 		Protocol:                protocol.CurrentProtocol,
@@ -71,6 +72,29 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 		CrossPlayDisabled:       false,
 		LevelID:                 levelID(st.LevelID),
 	}), nil
+}
+
+// applyQueriedStatus overlays a queried server status onto the announced one.
+func applyQueriedStatus(st *Status, queried minecraft.ServerStatus) {
+	st.WorldName = queried.ServerName
+	st.HostName = queried.ServerSubName
+	st.Players = queried.PlayerCount
+	st.MaxPlayers = queried.MaxPlayers
+}
+
+// hostNameFallback returns the account gamertag for empty host names, matching
+// MCXboxBroadcast, with a static fallback when no profile is available.
+func (b *Broadcaster) hostNameFallback() string {
+	client := b.conf.XBLClient
+	if client == nil {
+		client = b.xblClient
+	}
+	if client != nil {
+		if gamertag := client.UserInfo().GamerTag; gamertag != "" {
+			return gamertag
+		}
+	}
+	return "MCXboxBroadcast"
 }
 
 func (b *Broadcaster) primaryXUIDForStatus(ctx context.Context) (string, error) {
@@ -114,10 +138,10 @@ func normalizeStatus(status room.Status) room.Status {
 	}
 	status.WorldName = stripColour(status.WorldName)
 	if status.WorldType == "" {
-		status.WorldType = room.WorldTypeCreative
+		status.WorldType = WorldTypeSurvival
 	}
-	if status.MemberCount <= 0 {
-		status.MemberCount = 1
+	if status.MemberCount < 0 {
+		status.MemberCount = 0
 	}
 	if status.MaxMemberCount <= status.MemberCount {
 		status.MaxMemberCount = status.MemberCount + 1
@@ -140,7 +164,8 @@ func normalizeStatus(status room.Status) room.Status {
 	status.TransportLayer = p2p.TransportLayerNetherNet
 	status.OnlineCrossPlatformGame = true
 	if status.LevelID == "" {
-		status.LevelID = defaults.LevelID
+		// MCXboxBroadcast always sends the literal "level".
+		status.LevelID = "level"
 	}
 	return status
 }
@@ -257,7 +282,8 @@ func httpClient(c *http.Client) *http.Client {
 
 func queryStatus(ctx context.Context, address string, timeout time.Duration) (minecraft.ServerStatus, error) {
 	if timeout == 0 {
-		timeout = 5 * time.Second
+		// MCXboxBroadcast pings with a 1500 ms timeout.
+		timeout = 1500 * time.Millisecond
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/status_test.go
+++ b/status_test.go
@@ -3,6 +3,9 @@ package broadcaster
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/sandertv/gophertunnel/minecraft"
 
 	"github.com/sandertv/gophertunnel/minecraft/p2p"
 	"github.com/sandertv/gophertunnel/minecraft/room"
@@ -10,10 +13,9 @@ import (
 
 func TestStatusDefaults(t *testing.T) {
 	b, err := New(Config{
-		XBLTokenSource:  staticTokenSource{},
-		LiveTokenSource: staticOAuthSource{},
-		XUID:            "123",
-		Server:          ServerInfo{Host: "127.0.0.1", Port: 19132},
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
 		Status: Status{
 			HostName:   "§aHost",
 			WorldName:  "",
@@ -34,10 +36,10 @@ func TestStatusDefaults(t *testing.T) {
 	if status.WorldName != "Host" {
 		t.Fatalf("unexpected world name %q", status.WorldName)
 	}
-	if status.MemberCount != 1 {
-		t.Fatalf("unexpected member count %d", status.MemberCount)
+	if status.MemberCount != 0 {
+		t.Fatalf("unexpected member count %d (Java broadcasts 0 by default)", status.MemberCount)
 	}
-	if status.MaxMemberCount != 2 {
+	if status.MaxMemberCount != 1 {
 		t.Fatalf("unexpected max member count %d", status.MaxMemberCount)
 	}
 	if status.OwnerID != "123" {
@@ -54,10 +56,70 @@ func TestStatusDefaults(t *testing.T) {
 func TestNormalizeStatusKeepsDefaultLevelIDStable(t *testing.T) {
 	first := normalizeStatus(room.Status{HostName: "Host", WorldName: "World"})
 	second := normalizeStatus(room.Status{HostName: "Host", WorldName: "World"})
-	if first.LevelID == "" {
-		t.Fatal("expected default level ID")
+	if first.LevelID != "level" {
+		t.Fatalf("default level ID = %q, want Java's literal \"level\"", first.LevelID)
 	}
 	if first.LevelID != second.LevelID {
 		t.Fatalf("default level ID changed: %q != %q", first.LevelID, second.LevelID)
+	}
+}
+
+func TestStatusKeepsLastQueryResultWhenQueryFails(t *testing.T) {
+	b, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		// Port 1 on localhost is closed, so the query fails quickly.
+		Server: ServerInfo{Host: "127.0.0.1", Port: 1},
+		Status: Status{
+			HostName:     "Config Host",
+			WorldName:    "Config World",
+			QueryTarget:  true,
+			QueryTimeout: 50 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.lastQuery = &minecraft.ServerStatus{
+		ServerName:    "Queried World",
+		ServerSubName: "Queried Host",
+		PlayerCount:   7,
+		MaxPlayers:    30,
+	}
+	status, err := b.status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.WorldName != "Queried World" || status.HostName != "Queried Host" {
+		t.Fatalf("expected last query result to be kept, got %q/%q", status.WorldName, status.HostName)
+	}
+	if status.MemberCount != 7 || status.MaxMemberCount != 30 {
+		t.Fatalf("expected last query counts, got %d/%d", status.MemberCount, status.MaxMemberCount)
+	}
+}
+
+func TestStatusResetsToConfigWhenQueryFailsWithConfigFallback(t *testing.T) {
+	b, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 1},
+		Status: Status{
+			HostName:      "Config Host",
+			WorldName:     "Config World",
+			QueryTarget:   true,
+			QueryFallback: true,
+			QueryTimeout:  50 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.lastQuery = &minecraft.ServerStatus{ServerName: "Queried World", ServerSubName: "Queried Host"}
+	status, err := b.status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.WorldName != "Config World" || status.HostName != "Config Host" {
+		t.Fatalf("expected config fallback values, got %q/%q", status.WorldName, status.HostName)
 	}
 }

--- a/token.go
+++ b/token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,6 +32,14 @@ var minecraftServiceErrorPattern = regexp.MustCompile(`minecraft/service:\s*([^:
 // outbound authentication requests. If ctx carries oauth2.HTTPClient, that
 // client is used for device auth and refresh requests.
 func NewLiveTokenSource(ctx context.Context, tok *oauth2.Token, out io.Writer) oauth2.TokenSource {
+	return NewLiveTokenSourceWithPersist(ctx, tok, out, nil)
+}
+
+// NewLiveTokenSourceWithPersist is like NewLiveTokenSource but calls persist
+// with every newly issued token so rotated refresh tokens survive restarts.
+// When a cached refresh token is rejected by the server, the source falls back
+// to a fresh device-code login instead of failing until the cache is deleted.
+func NewLiveTokenSourceWithPersist(ctx context.Context, tok *oauth2.Token, out io.Writer, persist func(*oauth2.Token)) oauth2.TokenSource {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -38,10 +47,11 @@ func NewLiveTokenSource(ctx context.Context, tok *oauth2.Token, out io.Writer) o
 		out = io.Discard
 	}
 	return oauth2.ReuseTokenSource(tok, &liveTokenSource{
-		ctx:    ctx,
-		tok:    tok,
-		out:    out,
-		config: auth.AndroidConfig,
+		ctx:     ctx,
+		tok:     tok,
+		out:     out,
+		config:  auth.AndroidConfig,
+		persist: persist,
 	})
 }
 
@@ -168,10 +178,11 @@ func withDefaultXBLTokenCache(ctx context.Context) context.Context {
 }
 
 type liveTokenSource struct {
-	ctx    context.Context
-	tok    *oauth2.Token
-	out    io.Writer
-	config auth.Config
+	ctx     context.Context
+	tok     *oauth2.Token
+	out     io.Writer
+	config  auth.Config
+	persist func(*oauth2.Token)
 }
 
 func (s *liveTokenSource) Token() (*oauth2.Token, error) {
@@ -180,18 +191,31 @@ func (s *liveTokenSource) Token() (*oauth2.Token, error) {
 		defer cancel()
 
 		tok, err := refreshLiveToken(ctx, s.config.ClientID, s.tok.RefreshToken)
-		if err != nil {
+		if err == nil {
+			return s.store(tok), nil
+		}
+		// Only fall back to device-code login when the server rejected the
+		// refresh token; transient transport failures should surface instead
+		// of prompting a needless re-login.
+		var refreshErr *liveRefreshError
+		if !errors.As(err, &refreshErr) {
 			return nil, err
 		}
-		s.tok = tok
-		return tok, nil
 	}
 	tok, err := requestLiveTokenWriter(s.ctx, s.config, s.out)
 	if err != nil {
 		return nil, err
 	}
+	return s.store(tok), nil
+}
+
+// store records the newly issued token in memory and through the persist hook.
+func (s *liveTokenSource) store(tok *oauth2.Token) *oauth2.Token {
 	s.tok = tok
-	return tok, nil
+	if s.persist != nil {
+		s.persist(tok)
+	}
+	return tok
 }
 
 func requestLiveTokenWriter(ctx context.Context, conf auth.Config, out io.Writer) (*oauth2.Token, error) {
@@ -221,9 +245,20 @@ func refreshLiveToken(ctx context.Context, clientID, refreshToken string) (*oaut
 		return nil, fmt.Errorf("POST %s: json decode: %w", microsoft.LiveConnectEndpoint.TokenURL, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("POST %s: refresh error: %v: %v", microsoft.LiveConnectEndpoint.TokenURL, body.Error, body.ErrorDescription)
+		return nil, &liveRefreshError{Code: body.Error, Description: body.ErrorDescription}
 	}
 	return body.token(), nil
+}
+
+// liveRefreshError is a Microsoft Live token endpoint rejection of a refresh
+// token, such as invalid_grant for an expired or revoked token.
+type liveRefreshError struct {
+	Code        string
+	Description string
+}
+
+func (e *liveRefreshError) Error() string {
+	return fmt.Sprintf("POST %s: refresh error: %v: %v", microsoft.LiveConnectEndpoint.TokenURL, e.Code, e.Description)
 }
 
 func postLiveForm(ctx context.Context, endpoint string, form url.Values) (*http.Response, error) {

--- a/token.go
+++ b/token.go
@@ -195,10 +195,10 @@ func (s *liveTokenSource) Token() (*oauth2.Token, error) {
 			return s.store(tok), nil
 		}
 		// Only fall back to device-code login when the server rejected the
-		// refresh token; transient transport failures should surface instead
-		// of prompting a needless re-login.
+		// refresh token itself; transport failures and transient server
+		// errors should surface instead of prompting a needless re-login.
 		var refreshErr *liveRefreshError
-		if !errors.As(err, &refreshErr) {
+		if !errors.As(err, &refreshErr) || !refreshErr.requiresReauth() {
 			return nil, err
 		}
 	}
@@ -259,6 +259,13 @@ type liveRefreshError struct {
 
 func (e *liveRefreshError) Error() string {
 	return fmt.Sprintf("POST %s: refresh error: %v: %v", microsoft.LiveConnectEndpoint.TokenURL, e.Code, e.Description)
+}
+
+// requiresReauth reports whether the rejection means the refresh token is no
+// longer usable and a fresh login is required. Other OAuth error codes (such
+// as server_error or temporarily_unavailable) may succeed on retry.
+func (e *liveRefreshError) requiresReauth() bool {
+	return e.Code == "invalid_grant"
 }
 
 func postLiveForm(ctx context.Context, endpoint string, form url.Values) (*http.Response, error) {

--- a/token_test.go
+++ b/token_test.go
@@ -180,6 +180,26 @@ func TestLiveTokenSourceDoesNotFallBackToDeviceCodeOnTransientRefreshError(t *te
 	}
 }
 
+func TestLiveTokenSourceDoesNotFallBackToDeviceCodeOnTransientServerError(t *testing.T) {
+	// A non-200 with an OAuth error other than invalid_grant (or none at all)
+	// means the refresh token may still be usable; no re-login should start.
+	client := &http.Client{Transport: tokenRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return tokenTestResponse(http.StatusServiceUnavailable, `{"error":"server_error","error_description":"try again"}`), nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	src := NewLiveTokenSource(ctx, &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, io.Discard)
+
+	_, err := src.Token()
+	var refreshErr *liveRefreshError
+	if !errors.As(err, &refreshErr) || refreshErr.Code != "server_error" {
+		t.Fatalf("Token() error = %v, want surfaced refresh error", err)
+	}
+}
+
 func TestLiveTokenSourceFallsBackToDeviceCodeWhenRefreshRejected(t *testing.T) {
 	// The device-code flow starts with a POST to the device-code endpoint; the
 	// fallback is detected by observing that request after a refresh rejection.

--- a/token_test.go
+++ b/token_test.go
@@ -142,6 +142,75 @@ func TestNewLiveTokenSourceUsesContextHTTPClientForRefresh(t *testing.T) {
 	}
 }
 
+func TestLiveTokenSourcePersistsRotatedRefreshTokens(t *testing.T) {
+	client := &http.Client{Transport: tokenRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return tokenTestResponse(http.StatusOK, `{"access_token":"new-access","token_type":"bearer","refresh_token":"rotated-refresh","expires_in":3600}`), nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	var persisted []*oauth2.Token
+	src := NewLiveTokenSourceWithPersist(ctx, &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, io.Discard, func(tok *oauth2.Token) {
+		persisted = append(persisted, tok)
+	})
+
+	if _, err := src.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if len(persisted) != 1 || persisted[0].RefreshToken != "rotated-refresh" {
+		t.Fatalf("persisted tokens = %#v, want one with rotated-refresh", persisted)
+	}
+}
+
+func TestLiveTokenSourceDoesNotFallBackToDeviceCodeOnTransientRefreshError(t *testing.T) {
+	client := &http.Client{Transport: tokenRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	src := NewLiveTokenSource(ctx, &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, io.Discard)
+
+	if _, err := src.Token(); err == nil {
+		t.Fatal("expected transient refresh error to surface")
+	}
+}
+
+func TestLiveTokenSourceFallsBackToDeviceCodeWhenRefreshRejected(t *testing.T) {
+	// The device-code flow starts with a POST to the device-code endpoint; the
+	// fallback is detected by observing that request after a refresh rejection.
+	var urls []string
+	client := &http.Client{Transport: tokenRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		urls = append(urls, req.URL.String())
+		if req.URL.String() == "https://login.live.com/oauth20_token.srf" {
+			return tokenTestResponse(http.StatusBadRequest, `{"error":"invalid_grant","error_description":"expired"}`), nil
+		}
+		return nil, errors.New("stop device-code flow")
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	src := NewLiveTokenSource(ctx, &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+		Expiry:       time.Now().Add(-time.Hour),
+	}, io.Discard)
+
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("expected error from aborted device-code flow")
+	}
+	if len(urls) < 2 {
+		t.Fatalf("requests = %v, want refresh followed by device-code fallback", urls)
+	}
+	var refreshErr *liveRefreshError
+	if errors.As(err, &refreshErr) {
+		t.Fatalf("refresh rejection should have been superseded by device-code fallback, got %v", err)
+	}
+}
+
 func TestMinecraftTokenDiagnosticsFormatsPlayerBannedError(t *testing.T) {
 	baseErr := errors.New(`minecraft/service: PlayerBanned: "Player 2535433454914320 is banned." ()`)
 	src := withMinecraftTokenDiagnostics(failingMinecraftTokenSource{err: baseErr})


### PR DESCRIPTION
Validates and fixes the findings from the deep code review of this port against rtm516/MCXboxBroadcast @ e4190a5 (build 144). Every claim was verified against both codebases before fixing; none were refuted. 24 of 27 findings are addressed here.

## Bugs
- **Sub-account join (A1):** sub-accounts now look up the primary's activity handle (`ActivitiesForUsers`) and join via `mpsd.Client.Join` instead of re-publishing the session reference, which fails with 412 Precondition Failed.
- **Restricted accounts (A2):** follow failures with Xbox codes 1011/1049 force-unfollow the follower (`DELETE people/follower/xuid(...)`), send a friend-restriction webhook, and continue — one restricted account no longer starves the rest of the list forever.
- **Sync resilience (A3):** a single add/remove/expiry failure no longer aborts the pass; follow and unfollow rate limits are tracked separately so removals run while adds are limited (B11: backoff also no longer skips read-only scans).
- **Token rotation (A4):** rotated refresh tokens are persisted on every refresh via `NewLiveTokenSourceWithPersist`; a server-rejected refresh token falls back to device-code login instead of failing until the cache is deleted. Transient network errors still surface.
- **Config defaults (A5/A6):** `debugMode: false` in generated configs; dead `remoteAddress`/`remotePort: auto` keys and the unreachable `RuntimeConfigInput` resolver fields removed (Geyser-extension-only in Java).
- **Unjoinable sessions (A7):** `Start` errors when the session would publish `SupportedConnections: null` instead of warning and publishing anyway.

## Java parity
- `suppressSessionUpdateMessage` demotes the periodic success log to debug (Java semantics); the failure webhook is unconditional (B8).
- Query failures keep the last successful query result and still push the update; `configFallback` default restored to `false` (B9).
- Undecorated contract-5 follower/social fetches, single bulk `POST /bulk/.../friends/v2?method=add` accept, Java `DELETE people/xuid(...)` unfollow (B10).
- Guest XUIDs (`xuid>>52 == 1`) skipped unconditionally (B12).
- Client authentication enabled by default; player history records only verified XUIDs. NetherNet `AllowAnonymous` is unchanged — set `ListenConfig.AuthenticationDisabled` explicitly if unsigned chains must connect (B13).
- Player history pruned for people no longer on the friend list; JSON format documented as a deliberate divergence from Java's SQLite (B14).
- Session document parity: numeric `NetherNetId`, `isHardcore: false`, Survival default `worldType`, literal `"level"` levelId, `players: 0` allowed, 1500 ms ping timeout, gamertag hostname fallback, UTC-with-millis gallery timetaken, sub-account mutual-follow pre-check + 5 s settle (B15/B16).

## Parity gaps closed
- **Self-healing (C17):** health check before each update recreates the full stack (signaling, session, handle, sub-sessions) on dead MPSD/sub-session contexts, ≥28/30 members, or 3 consecutive update failures; gallery re-showcases after recreation.
- **Sub-account friend sync (C18):** one syncer per enabled sub-account (primary config inherited unless overridden); a failing sub-account is logged and skipped instead of aborting startup.
- **Sign-in webhook (C19):** device-code URL + code are pushed to the webhook for primary and sub-account logins.
- **Assorted (C23):** Docker runs as `app:app`, migrated configs are written back to disk, clamped config values warn loudly, "authenticated … N/2000 friends" startup log.

## Docs & cleanup
- README: title `go-mcxboxbroadcast`, go-xsapi + go-raknet fork replaces disclosed, auto-address claim removed, library example updated (D24–D26).
- Dead `Config.LiveTokenSource`/`SubAccountConfig.LiveTokenSource` removed (breaking; no downstream importers); `TransferCloseTimeout` exposed on `Config`; `SupportedConnections` override documented as deliberate (E).

## Not addressed (validated, deferred)
- C20 full token-chain caching (needs `sisu.Session.Snapshot` wiring through the gophertunnel auth layer — cross-repo)
- C21 interactive console
- C22 real-time friend accept via social RTA (fork ships the subscription; needs the client-owned social path)
- B16 protocol-mismatch Disconnect packet (lives in the gophertunnel fork's listener)

`go build`, `go vet`, and the full test suite pass; new regression tests cover each behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch Xbox Live session publishing, MPSD join semantics, OAuth token persistence, and default client authentication—any regression affects joinability, friend automation, or headless recovery.
> 
> **Overview**
> This PR closes a large gap between the Go port and **MCXboxBroadcast (Java)** across Xbox session lifecycle, social APIs, config, auth, and ops.
> 
> **Session & sub-accounts:** Sub-accounts **join** the primary MPSD session via the primary’s activity handle instead of re-publishing (avoids 412). Failed sub-accounts are skipped with notifications; mutual-follow is idempotent with a settle delay. **Health checks** before periodic updates recreate signaling, the session, sub-sessions, and the listener when MPSD/sub-sessions die, member count hits 28/30, or updates fail three times in a row. Startup **fails** if the session would publish no joinable connections.
> 
> **Friend sync:** Follow/unfollow rate limits are independent; one failure no longer aborts the pass. Restricted followers are **force-unfollowed** with webhook notice. Per–sub-account syncers inherit primary config; primary **history pruning** is disabled when sub-account syncers share the store. Pending accepts use **bulk add**; people lists use undecorated contract 5.
> 
> **Status & auth:** Query failures keep the **last good** ping unless `configFallback` is true; defaults align with Java (Survival, `level`, 0 players, gamertag hostname, session JSON shape). NetherNet clients authenticate by default. Live tokens **persist on refresh** and fall back to device code only on `invalid_grant`. Device-code prompts can go to webhooks; rotated tokens save from the CLI.
> 
> **Config & Docker:** Removes Geyser-only `remoteAddress`/`remotePort`, dead `LiveTokenSource` fields, and clamps invalid values with **Notes** warnings; migrated configs write back. Container runs as non-root **`app`** with correct volume ownership.
> 
> Docs rename the project to **go-mcxboxbroadcast** and document fork replaces and JSON expiry history vs Java SQLite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce4d752b8229ade1026f9b3480420fa7bd45f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable account token handling, including persisted token rotation.
  * Improved session status output and connection details for better compatibility.
  * Added friend-sync notifications and history cleanup support.

* **Bug Fixes**
  * Better recovery when queries or updates fail, including fallback to the last known status.
  * Friend sync now handles rate limits more gracefully and skips invalid guest entries consistently.
  * Container runtime now runs with a dedicated user for safer default permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->