### PR TITLE
Authenticate gallery image reads and fix startup friend count

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -293,19 +293,21 @@ func (b *Broadcaster) startSubAccountFriendSync() {
 }
 
 // logSocialSummary logs the authenticated account and its friend usage at
-// startup, mirroring MCXboxBroadcast's "N/2000 friends" line.
+// startup, mirroring MCXboxBroadcast's "N/2000 friends" line. The count comes
+// from the friend list like MCXboxBroadcast; the social summary's
+// targetFollowingCount is unreliable for the caller's own profile.
 func (b *Broadcaster) logSocialSummary() {
 	ctx, cancel := context.WithTimeout(b.ctx, 15*time.Second)
 	defer cancel()
-	summary, err := b.friendClientFor(b.conf.XBLClient).Summary(ctx)
+	friends, err := b.friendClientFor(b.conf.XBLClient).Friends(ctx)
 	if err != nil {
-		b.debug("fetch social summary", "err", err)
+		b.debug("fetch friend list for summary", "err", err)
 		return
 	}
 	b.info("authenticated to xbox live",
 		"gamertag", b.hostNameFallback(),
 		"xuid", b.primaryXUID(),
-		"friends", fmt.Sprintf("%d/2000", summary.TargetFollowingCount),
+		"friends", fmt.Sprintf("%d/2000", len(friends)),
 	)
 }
 

--- a/gallery.go
+++ b/gallery.go
@@ -186,10 +186,9 @@ func (g GalleryClient) Delete(ctx context.Context, imageID string) error {
 }
 
 func (g GalleryClient) remoteImageHash(ctx context.Context, url string) (uint32, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	// The gallery image endpoint requires the Minecraft service token even for
+	// reads; an unauthenticated fetch returns 401 and forces a re-upload.
+	req, err := g.request(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/gallery_test.go
+++ b/gallery_test.go
@@ -55,6 +55,44 @@ func TestGalleryClientReusesReencodedEquivalentImage(t *testing.T) {
 	}
 }
 
+func TestGalleryClientAuthenticatesRemoteImageFetch(t *testing.T) {
+	remoteImage := testPNG(t, png.NoCompression)
+	imagePath := filepath.Join(t.TempDir(), "image.png")
+	if err := os.WriteFile(imagePath, remoteImage, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	g := GalleryClient{
+		TokenSource: galleryMinecraftTokenSource{},
+		Client: &http.Client{Transport: galleryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/xuid/1"):
+				return galleryHTTPResponse(http.StatusOK, `{"result":{"showcasedImages":[{"id":"img","url":"https://cdn.example.test/image.png"}]}}`), nil
+			case req.Method == http.MethodGet && req.URL.Host == "cdn.example.test":
+				// The image endpoint rejects unauthenticated requests with 401,
+				// which used to force a needless re-upload on every start.
+				if req.Header.Get("Authorization") != "Bearer minecraft" {
+					return galleryHTTPResponse(http.StatusUnauthorized, ""), nil
+				}
+				return responseBytes(http.StatusOK, remoteImage), nil
+			case req.Method == http.MethodPost && req.URL.Path == "/api/v1.0/gallery":
+				t.Fatal("image should have been reused instead of uploaded")
+			default:
+				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
+			}
+			return nil, nil
+		})},
+	}
+
+	result, err := g.SetShowcaseResult(context.Background(), "1", imagePath, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.AlreadySet {
+		t.Fatal("expected authenticated image fetch to recognise the existing showcase image")
+	}
+}
+
 func TestGalleryClientSetShowcaseResultReportsExistingImage(t *testing.T) {
 	localImage := testPNG(t, png.BestCompression)
 	remoteImage := testPNG(t, png.NoCompression)

--- a/integration_clients_test.go
+++ b/integration_clients_test.go
@@ -167,33 +167,6 @@ func TestGalleryClientUploadsImageWhenConfigured(t *testing.T) {
 	}
 }
 
-func TestGalleryClientDoesNotSendAuthToImageURL(t *testing.T) {
-	imagePath := testGalleryImageFile(t)
-	imageBytes := testGalleryImageBytes(t)
-	g := GalleryClient{
-		TokenSource: staticMinecraftTokenSource{},
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			switch {
-			case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/xuid/1"):
-				return response(http.StatusOK, `{"result":{"showcasedImages":[{"id":"img","url":"https://cdn.example.test/image.jpg"}]}}`), nil
-			case req.Method == http.MethodGet && req.URL.Host == "cdn.example.test":
-				if req.Header.Get("Authorization") != "" {
-					t.Fatal("authorization header sent to gallery image URL")
-				}
-				return responseBytes(http.StatusOK, imageBytes), nil
-			case req.Method == http.MethodPost && req.URL.Path == "/api/v1.0/gallery":
-				t.Fatal("image should have been reused instead of uploaded")
-			default:
-				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
-			}
-			return nil, nil
-		})},
-	}
-	if err := g.SetShowcase(context.Background(), "1", imagePath, true); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestGalleryClientReportsDeleteFailures(t *testing.T) {
 	imagePath := testGalleryImageFile(t)
 	imageBytes := testGalleryImageBytes(t)


### PR DESCRIPTION
## What

Two fixes found while debugging the eu-west deployment logs:

**Gallery image re-uploaded on every start (401 on hash compare).** The image URL returned by the showcase API rejects unauthenticated GETs:

```
failed to compare gallery image ... GET https://persona-secondary.franchise.minecraft-services.net/api/v1.0/gallery/pfid/.../...: 401 Unauthorized
```

so `SetShowcaseResult` never recognised the already-uploaded image and re-POSTed it on every boot. Image reads now send the Minecraft service token, matching MCXboxBroadcast's `GalleryManager#getImage`, which sends `Authorization` on the image URL fetch. The prior `TestGalleryClientDoesNotSendAuthToImageURL` encoded the opposite policy and is replaced by `TestGalleryClientAuthenticatesRemoteImageFetch` (fake 401s without the header, like the live service).

**Startup friend count wrong.** `authenticated to xbox live ... friends=1/2000` while the account has 192 friends: the social summary's `targetFollowingCount` is unreliable for the caller's own profile. Count the friend list instead, which is also what MCXboxBroadcast logs (`friendManager.get().size()`).

## Verification

- `go test ./... -count=1`, `go vet`, `gofmt` clean
- Live log evidence in eu-west pod `go-mcxboxbroadcast-66cbd566d-spqbx` (2026-07-02 01:03 UTC startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fixes to gallery HTTP auth and startup logging; no session, auth, or join-path changes. Gallery behavior now matches live API requirements.
> 
> **Overview**
> Fixes two startup/operational bugs: **gallery dedupe** and **Xbox friend logging**.
> 
> **Showcase image** — `SetShowcaseResult` compares local pixels to remote showcase URLs via `remoteImageHash`. Those GETs now go through `GalleryClient.request` so the **Minecraft service token** is sent (same as MCXboxBroadcast). Unauthenticated reads were returning **401**, hash compare failed every boot, and the image was **re-uploaded** each time. Tests now assert auth on the CDN fetch and drop the old “must not send Authorization” integration test.
> 
> **Startup friend line** — `logSocialSummary` no longer uses the social summary’s `targetFollowingCount` (wrong for the caller’s own profile, e.g. `1/2000` vs ~192 friends). It uses **`Friends()`** and logs `len(friends)` for the `N/2000` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bbc9ec39c89bb6df4362d5929cb1762db3f7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gallery images are now fetched with the proper authentication, improving reuse of existing showcase images and reducing unnecessary re-uploads.
  * Social summary logging now reflects the account’s friend list count more accurately.
* **Tests**
  * Added coverage for authenticated gallery image retrieval.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->