### PR TITLE
Normalize friendly-cased joinability values to wire values

### DIFF
--- a/config_file.go
+++ b/config_file.go
@@ -256,6 +256,26 @@ func (c *ConfigFile) migrate() {
 	if c.Gallery.ImagePath == "" {
 		c.Gallery.ImagePath = "screenshot.jpg"
 	}
+	c.Session.Joinability = c.normalizeJoinability(c.Session.Joinability)
+}
+
+// normalizeJoinability maps friendly-cased joinability names to the wire
+// values the session document must carry. Clients drop worlds whose
+// Joinability is not exactly "joinable_by_friends", leaving the account
+// visible only as an online friend.
+func (c *ConfigFile) normalizeJoinability(value string) string {
+	switch strings.ToLower(strings.ReplaceAll(value, "_", "")) {
+	case "", "joinablebyfriends":
+		if value == "" {
+			return ""
+		}
+		return JoinabilityJoinableByFriends
+	case "inviteonly":
+		return JoinabilityInviteOnly
+	default:
+		c.note("session.joinability %q is not a known value; using %q", value, JoinabilityJoinableByFriends)
+		return JoinabilityJoinableByFriends
+	}
 }
 
 func (c *ConfigFile) note(format string, args ...any) {

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -119,7 +119,7 @@ accounts:
 	if cfg.Session.UpdateInterval != 45 || cfg.Session.QueryServer || !cfg.Session.WebQueryFallback || cfg.Session.ConfigFallback {
 		t.Fatalf("session query aliases were not loaded: %#v", cfg.Session)
 	}
-	if cfg.Session.BroadcastSetting != 2 || cfg.Session.Joinability != "InviteOnly" || cfg.Session.WorldType != "Creative" {
+	if cfg.Session.BroadcastSetting != 2 || cfg.Session.Joinability != JoinabilityInviteOnly || cfg.Session.WorldType != "Creative" {
 		t.Fatalf("session status aliases were not loaded: %#v", cfg.Session)
 	}
 	if cfg.Session.SessionInfo.HostName != "Example Host" || cfg.Session.SessionInfo.MaxPlayers != 32 {
@@ -233,6 +233,38 @@ func TestConfigFileToConfigMapsOperatorSettings(t *testing.T) {
 	}
 	if runtime.FriendHistory == nil {
 		t.Fatal("friend history store not mapped")
+	}
+}
+
+// TestConfigFileNormalizesJoinability guards against friendly-cased config
+// values reaching the session document verbatim: a "JoinableByFriends" doc is
+// filtered out by clients expecting the wire value, so the bot shows as an
+// online friend without a joinable world.
+func TestConfigFileNormalizesJoinability(t *testing.T) {
+	for input, want := range map[string]string{
+		"JoinableByFriends":   JoinabilityJoinableByFriends,
+		"joinable_by_friends": JoinabilityJoinableByFriends,
+		"InviteOnly":          JoinabilityInviteOnly,
+		"invite_only":         JoinabilityInviteOnly,
+		"":                    "",
+	} {
+		cfg := DefaultConfigFile()
+		cfg.Session.Joinability = input
+		cfg.migrate()
+		runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.Status.Joinability != want {
+			t.Errorf("joinability %q = %q, want %q", input, runtime.Status.Joinability, want)
+		}
+	}
+
+	cfg := DefaultConfigFile()
+	cfg.Session.Joinability = "sometimes"
+	cfg.migrate()
+	if len(cfg.Notes) == 0 {
+		t.Error("expected a migration note for an unrecognised joinability value")
 	}
 }
 


### PR DESCRIPTION
## What

`joinability: JoinableByFriends` in the config reached the MPSD session document verbatim. Clients (verified with Lunar's friend-worlds probe, which uses the same `p2p.Worlds` data the game reads) drop any world whose `Joinability` is not exactly `joinable_by_friends`, so the bot showed up as an **online friend with no joinable world card**. The Java broadcaster always sends the wire value (`CreateSessionRequest` hardcodes `joinable_by_friends`).

Config loading now normalizes `JoinableByFriends` / `InviteOnly` (any casing, with or without underscores) to the wire constants, and unknown values default to `joinable_by_friends` with a migration note.

## Evidence

Probe run against the live eu-west deployment before the fix:

```
filtered friend worlds count=16 reasons=map[not_joinable_by_friends:1 realm_or_experience:15]
```

The one `not_joinable_by_friends` entry was PlayLunarMC2's session carrying `"Joinability":"JoinableByFriends"`.

## Verification

- `go test ./... -count=1`, `go vet`, `gofmt` clean
- New `TestConfigFileNormalizesJoinability`; kebab-case alias test updated to expect the normalized wire value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized config migration change with tests; no auth or data-path changes, only session metadata formatting.
> 
> **Overview**
> **Config migration now normalizes `session.joinability`** so friendly or mixed-case strings (e.g. `JoinableByFriends`, `invite_only`) are converted to the wire constants clients expect (`joinable_by_friends`, `invite_only`). Without this, MPSD session docs could carry display-style values and friend lists would show the account online but **not** as a joinable world.
> 
> Unknown joinability values default to `joinable_by_friends` and append a migration **note** on the loaded config. Empty string stays empty.
> 
> Tests add `TestConfigFileNormalizesJoinability` and update the kebab-case alias test to assert the normalized wire value for `InviteOnly`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 888a3e8973937a5a8d3cc2577563f70653142bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->