### PR TITLE
[codex] Add Pterodactyl image support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,23 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          target: standalone
           push: true
           tags: |
             ${{ env.DOCKER_IMAGE }}:${{ github.sha }}
             ${{ env.DOCKER_IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push Pterodactyl image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: pterodactyl
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE }}:${{ github.sha }}-pterodactyl
+            ${{ env.DOCKER_IMAGE }}:pterodactyl
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,32 @@ COPY . .
 
 RUN --mount=type=cache,target="/home/.cache/go-build" CGO_ENABLED=0 go build -ldflags="-s -w" -o /app/mcxboxbroadcast_bin ./cmd/broadcaster
 
-FROM alpine:3.22
+FROM alpine:3.22 AS runtime-base
 
 RUN apk add --no-cache ca-certificates && update-ca-certificates
+
+COPY --from=build /app/mcxboxbroadcast_bin /mcxboxbroadcast
+
+FROM runtime-base AS pterodactyl
+
+RUN addgroup -S container && adduser -S -G container -h /home/container container
+
+ENV USER=container HOME=/home/container
+
+WORKDIR /home/container
+
+COPY deployments/pterodactyl/entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
+USER container:container
+
+CMD ["/bin/sh", "/entrypoint.sh"]
+
+FROM runtime-base AS standalone
 
 RUN addgroup -S app && adduser -S -G app -h /opt/app app
 
 WORKDIR /opt/app/config
-
-COPY --from=build /app/mcxboxbroadcast_bin /mcxboxbroadcast
 
 # chown must precede VOLUME: build steps that modify a path after it is
 # declared a volume are discarded, leaving the mount root-owned at runtime.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ stores token cache, player history, and gallery assets. With the default
 configuration, putting `screenshot.jpg` in that directory makes it the showcased
 image.
 
+## Pterodactyl
+
+Import `deployments/pterodactyl/egg-go-mcxboxbroadcast.json` into a Pterodactyl
+nest to run the broadcaster from the panel. The egg uses the Pterodactyl-specific
+image published at `ghcr.io/hashimthearab/go-mcxboxbroadcast:pterodactyl`,
+which runs as the required `container` user from `/home/container`.
+
+The egg creates `config.yml` on install and exposes the target Bedrock
+host/port, displayed server names, query behavior, notifications, and gallery
+settings as panel variables. Account tokens, friend history, and other runtime
+state are stored under `/home/container/cache`. On first start, complete the
+Microsoft device-code sign-in shown in the console; if notifications are
+enabled, the sign-in prompt is also sent to the configured webhook.
+
 ## Library
 
 ```go

--- a/deployments/pterodactyl/egg-go-mcxboxbroadcast.json
+++ b/deployments/pterodactyl/egg-go-mcxboxbroadcast.json
@@ -1,0 +1,152 @@
+{
+    "_comment": "Pterodactyl egg for go-mcxboxbroadcast.",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2026-07-04T00:00:00+00:00",
+    "name": "go-mcxboxbroadcast",
+    "author": "hashim@lunarbedrock.com",
+    "description": "Publishes a Minecraft: Bedrock Edition server as an Xbox Live friend-list world and transfers joining clients to the configured Bedrock server.",
+    "features": null,
+    "docker_images": {
+        "go-mcxboxbroadcast (Pterodactyl)": "ghcr.io/hashimthearab/go-mcxboxbroadcast:pterodactyl"
+    },
+    "file_denylist": [],
+    "startup": "/mcxboxbroadcast -config /home/container/config.yml",
+    "config": {
+        "files": "{\n    \"config.yml\": {\n        \"parser\": \"yaml\",\n        \"find\": {\n            \"debugMode\": \"{{server.build.env.DEBUG_MODE}}\",\n            \"session.queryServer\": \"{{server.build.env.QUERY_SERVER}}\",\n            \"session.configFallback\": \"{{server.build.env.CONFIG_FALLBACK}}\",\n            \"session.sessionInfo.hostName\": \"{{server.build.env.HOST_NAME}}\",\n            \"session.sessionInfo.worldName\": \"{{server.build.env.WORLD_NAME}}\",\n            \"session.sessionInfo.maxPlayers\": \"{{server.build.env.MAX_PLAYERS}}\",\n            \"session.sessionInfo.ip\": \"{{server.build.env.TARGET_SERVER_HOST}}\",\n            \"session.sessionInfo.port\": \"{{server.build.env.TARGET_SERVER_PORT}}\",\n            \"notifications.enabled\": \"{{server.build.env.NOTIFICATIONS_ENABLED}}\",\n            \"notifications.webhookUrl\": \"{{server.build.env.WEBHOOK_URL}}\",\n            \"gallery.enabled\": \"{{server.build.env.GALLERY_ENABLED}}\",\n            \"gallery.imagePath\": \"{{server.build.env.GALLERY_IMAGE_PATH}}\"\n        }\n    }\n}",
+        "startup": "{\n    \"done\": \"broadcasting\"\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!/bin/ash\nset -eu\n\ncd /mnt/server\nmkdir -p cache\n\nif [ ! -f config.yml ]; then\n    cat > config.yml <<EOF\nconfigVersion: 3\ndebugMode: ${DEBUG_MODE}\nsuppressSessionUpdateMessage: false\n\nhttp:\n  proxy: \"\"\n\nsession:\n  updateInterval: 30\n  signalingMode: jsonrpc\n  queryServer: ${QUERY_SERVER}\n  webQueryFallback: false\n  configFallback: ${CONFIG_FALLBACK}\n  broadcastSetting: 3\n  worldType: Survival\n  sessionInfo:\n    hostName: \"${HOST_NAME}\"\n    worldName: \"${WORLD_NAME}\"\n    players: 0\n    maxPlayers: ${MAX_PLAYERS}\n    ip: \"${TARGET_SERVER_HOST}\"\n    port: ${TARGET_SERVER_PORT}\n\nfriendSync:\n  updateInterval: 60\n  autoFollow: true\n  autoUnfollow: true\n  initialInvite: true\n  expiry:\n    enabled: true\n    days: 15\n    check: 1800\n    historyPath: cache/player_history.json\n\nnotifications:\n  enabled: ${NOTIFICATIONS_ENABLED}\n  webhookUrl: \"${WEBHOOK_URL}\"\n\ngallery:\n  enabled: ${GALLERY_ENABLED}\n  imagePath: \"${GALLERY_IMAGE_PATH}\"\n  deleteOtherImages: true\n\naccounts:\n  primaryCachePath: cache/live_token.json\n  subAccounts: []\nEOF\nfi\n\necho \"go-mcxboxbroadcast configuration is ready. Start the server and complete the Microsoft device-code sign-in shown in the console.\"\n",
+            "container": "ghcr.io/pterodactyl/installers:alpine",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Target Server Host",
+            "description": "Hostname or IP address of the Bedrock server players should be transferred to.",
+            "env_variable": "TARGET_SERVER_HOST",
+            "default_value": "play.example.net",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|regex:/^[a-zA-Z0-9_.:-]+$/|max:255",
+            "field_type": "text"
+        },
+        {
+            "name": "Target Server Port",
+            "description": "UDP port of the Bedrock server players should be transferred to.",
+            "env_variable": "TARGET_SERVER_PORT",
+            "default_value": "19132",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1,65535",
+            "field_type": "text"
+        },
+        {
+            "name": "Host Name",
+            "description": "Server name shown in the Minecraft friend-list world.",
+            "env_variable": "HOST_NAME",
+            "default_value": "Minecraft Server",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:80",
+            "field_type": "text"
+        },
+        {
+            "name": "World Name",
+            "description": "World name shown in the Minecraft friend-list world.",
+            "env_variable": "WORLD_NAME",
+            "default_value": "Minecraft World",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:80",
+            "field_type": "text"
+        },
+        {
+            "name": "Max Players",
+            "description": "Displayed max player count when the target server is not queried.",
+            "env_variable": "MAX_PLAYERS",
+            "default_value": "20",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:1,100000",
+            "field_type": "text"
+        },
+        {
+            "name": "Query Target Server",
+            "description": "Whether to query the target Bedrock server for live displayed status.",
+            "env_variable": "QUERY_SERVER",
+            "default_value": "true",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Use Config Fallback",
+            "description": "Whether failed target queries should reset displayed status to configured values.",
+            "env_variable": "CONFIG_FALLBACK",
+            "default_value": "false",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Debug Mode",
+            "description": "Enable verbose runtime logging.",
+            "env_variable": "DEBUG_MODE",
+            "default_value": "false",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Notifications Enabled",
+            "description": "Enable Slack or Discord-compatible webhook notifications.",
+            "env_variable": "NOTIFICATIONS_ENABLED",
+            "default_value": "false",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Webhook URL",
+            "description": "Slack or Discord-compatible webhook URL for notifications and headless sign-in prompts.",
+            "env_variable": "WEBHOOK_URL",
+            "default_value": "",
+            "user_viewable": false,
+            "user_editable": true,
+            "rules": "nullable|string|max:1000",
+            "field_type": "text"
+        },
+        {
+            "name": "Gallery Enabled",
+            "description": "Enable Minecraft profile showcase image upload.",
+            "env_variable": "GALLERY_ENABLED",
+            "default_value": "true",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|boolean",
+            "field_type": "text"
+        },
+        {
+            "name": "Gallery Image Path",
+            "description": "Path to the showcase image inside the server files.",
+            "env_variable": "GALLERY_IMAGE_PATH",
+            "default_value": "screenshot.jpg",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:255",
+            "field_type": "text"
+        }
+    ]
+}

--- a/deployments/pterodactyl/entrypoint.sh
+++ b/deployments/pterodactyl/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+cd /home/container
+
+STARTUP=${STARTUP:-"/mcxboxbroadcast -config /home/container/config.yml"}
+MODIFIED_STARTUP=$(eval echo "$(printf '%s' "$STARTUP" | sed -e 's/{{/${/g' -e 's/}}/}/g')")
+
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+exec sh -c "${MODIFIED_STARTUP}"

--- a/pterodactyl_test.go
+++ b/pterodactyl_test.go
@@ -1,0 +1,108 @@
+package broadcaster
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPterodactylArtifacts(t *testing.T) {
+	eggData, err := os.ReadFile("deployments/pterodactyl/egg-go-mcxboxbroadcast.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var egg struct {
+		Meta struct {
+			Version string `json:"version"`
+		} `json:"meta"`
+		Name         string            `json:"name"`
+		DockerImages map[string]string `json:"docker_images"`
+		Startup      string            `json:"startup"`
+		Config       struct {
+			Files   string `json:"files"`
+			Startup string `json:"startup"`
+			Logs    string `json:"logs"`
+			Stop    string `json:"stop"`
+		} `json:"config"`
+		Scripts struct {
+			Installation struct {
+				Container  string `json:"container"`
+				Entrypoint string `json:"entrypoint"`
+			} `json:"installation"`
+		} `json:"scripts"`
+		Variables []struct {
+			EnvVariable string `json:"env_variable"`
+		} `json:"variables"`
+	}
+	if err := json.Unmarshal(eggData, &egg); err != nil {
+		t.Fatalf("parse egg json: %v", err)
+	}
+	if egg.Meta.Version != "PTDL_v2" {
+		t.Fatalf("egg version = %q, want PTDL_v2", egg.Meta.Version)
+	}
+	if egg.Name != "go-mcxboxbroadcast" {
+		t.Fatalf("egg name = %q, want go-mcxboxbroadcast", egg.Name)
+	}
+	if got := egg.DockerImages["go-mcxboxbroadcast (Pterodactyl)"]; got != "ghcr.io/hashimthearab/go-mcxboxbroadcast:pterodactyl" {
+		t.Fatalf("pterodactyl image = %q", got)
+	}
+	if egg.Startup != "/mcxboxbroadcast -config /home/container/config.yml" {
+		t.Fatalf("startup = %q", egg.Startup)
+	}
+	if egg.Config.Stop != "^C" {
+		t.Fatalf("stop command = %q, want ^C", egg.Config.Stop)
+	}
+	if egg.Scripts.Installation.Container != "ghcr.io/pterodactyl/installers:alpine" {
+		t.Fatalf("install container = %q", egg.Scripts.Installation.Container)
+	}
+	if egg.Scripts.Installation.Entrypoint != "ash" {
+		t.Fatalf("install entrypoint = %q", egg.Scripts.Installation.Entrypoint)
+	}
+	for name, raw := range map[string]string{
+		"config.files":   egg.Config.Files,
+		"config.startup": egg.Config.Startup,
+		"config.logs":    egg.Config.Logs,
+	} {
+		var parsed any
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			t.Fatalf("%s is not valid json: %v", name, err)
+		}
+	}
+
+	var seenTargetHost, seenTargetPort bool
+	for _, variable := range egg.Variables {
+		seenTargetHost = seenTargetHost || variable.EnvVariable == "TARGET_SERVER_HOST"
+		seenTargetPort = seenTargetPort || variable.EnvVariable == "TARGET_SERVER_PORT"
+	}
+	if !seenTargetHost || !seenTargetPort {
+		t.Fatalf("target server variables missing: host=%v port=%v", seenTargetHost, seenTargetPort)
+	}
+
+	dockerfile, err := os.ReadFile("Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dockerfileText := string(dockerfile)
+	for _, want := range []string{
+		"FROM runtime-base AS pterodactyl",
+		"adduser -S -G container -h /home/container container",
+		"ENV USER=container HOME=/home/container",
+		"WORKDIR /home/container",
+		"COPY deployments/pterodactyl/entrypoint.sh /entrypoint.sh",
+		"FROM runtime-base AS standalone",
+	} {
+		if !strings.Contains(dockerfileText, want) {
+			t.Fatalf("Dockerfile does not contain %q", want)
+		}
+	}
+
+	workflow, err := os.ReadFile(".github/workflows/docker.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(workflow), "${{ env.DOCKER_IMAGE }}:pterodactyl") {
+		t.Fatal("docker workflow does not publish the pterodactyl tag")
+	}
+}


### PR DESCRIPTION
## Summary

Adds first-class Pterodactyl support for go-mcxboxbroadcast.

- keeps the existing GHCR `latest` image behavior on a `standalone` Docker target
- adds a Pterodactyl Docker target published as `ghcr.io/hashimthearab/go-mcxboxbroadcast:pterodactyl`
- adds an importable Pterodactyl egg with panel variables for target server, display names, query behavior, notifications, and gallery settings
- documents the Pterodactyl path in the README
- adds a focused artifact test covering the egg shape and Docker/workflow wiring

## Validation

- `go test ./...`
- `docker build --target standalone -t go-mcxboxbroadcast:standalone-review .`
- `docker build --target pterodactyl -t go-mcxboxbroadcast:pterodactyl-review .`
- `docker image inspect go-mcxboxbroadcast:pterodactyl-review --format '{{.Config.User}} {{.Config.WorkingDir}} {{json .Config.Cmd}}'`
- `docker run --rm -e STARTUP='printf ptero-review' go-mcxboxbroadcast:pterodactyl-review`
- ran the egg install script inside `ghcr.io/pterodactyl/installers:alpine` with a temp `/mnt/server` mount and verified generated `config.yml`/`cache`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Docker packaging, CI tags, deployment artifacts, and tests; application runtime logic is unchanged.
> 
> **Overview**
> **Adds first-class Pterodactyl deployment** alongside the existing Docker path. The `Dockerfile` is refactored into a shared `runtime-base` stage plus two final targets: **`standalone`** (same `/opt/app` user, config volume, and default CMD as before) and **`pterodactyl`** (runs as `container` under `/home/container` with `deployments/pterodactyl/entrypoint.sh` for panel-style `STARTUP` substitution).
> 
> The **GitHub Actions docker workflow** now builds `standalone` explicitly for `latest`/`sha` tags and adds a second push for **`pterodactyl`** (`:pterodactyl` and `:${{ github.sha }}-pterodactyl`).
> 
> New **`deployments/pterodactyl/egg-go-mcxboxbroadcast.json`** wires panel variables into `config.yml`, seeds install-time config/cache paths, and points at the Pterodactyl image. **README** documents import and first-run sign-in. **`pterodactyl_test.go`** guards egg JSON, Dockerfile strings, and workflow tag wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a4f6a0b2b644d8a581d4048cc884d63afe3f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Pterodactyl deployment option with dedicated container image tags and startup behavior.
  * Split container builds so both standalone and Pterodactyl images are published automatically.

* **Documentation**
  * Added setup guidance for deploying via Pterodactyl, including configuration options, runtime paths, and first-run sign-in notes.

* **Tests**
  * Added checks to ensure the Pterodactyl deployment artifacts and image publishing setup stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->