### PR TITLE
Update go-xsapi social APIs

### DIFF
--- a/friends.go
+++ b/friends.go
@@ -60,12 +60,6 @@ func (c FriendClient) Friends(ctx context.Context) ([]Person, error) {
 	return mergePeople(peopleFromSocialUsers(followers), peopleFromSocialUsers(following)), nil
 }
 
-// Summary returns the caller's social summary, including the total number of
-// people the account follows.
-func (c FriendClient) Summary(ctx context.Context) (xblsocial.Summary, error) {
-	return c.social().Summary(ctx)
-}
-
 // AcceptPendingFriendRequests accepts incoming Xbox friend requests with a
 // single bulk add call and returns the people that Xbox reported as updated.
 func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person, error) {
@@ -87,7 +81,7 @@ func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person
 		return nil, nil
 	}
 
-	updatedXUIDs, err := socialClient.BulkAddFriends(ctx, xuids)
+	updatedXUIDs, err := socialClient.AddFriends(ctx, xuids)
 	if err != nil {
 		return nil, err
 	}

--- a/friends_test.go
+++ b/friends_test.go
@@ -26,6 +26,10 @@ func followURL(xuid string) string {
 	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/xuid(%s)", xuid)
 }
 
+func unfollowURL(xuid string) string {
+	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/friends/v2/xuid(%s)?deleteRelationships=follows", xuid)
+}
+
 func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 	var requests []string
 	client := FriendClient{
@@ -124,7 +128,7 @@ func TestFriendClientUnfollowReturnsRetryAfterError(t *testing.T) {
 			if req.Method != http.MethodDelete {
 				t.Fatalf("unexpected method %s", req.Method)
 			}
-			if req.URL.String() != followURL("123") {
+			if req.URL.String() != unfollowURL("123") {
 				t.Fatalf("unexpected URL %s", req.URL)
 			}
 			resp := response(http.StatusTooManyRequests, "")

--- a/friends_test.go
+++ b/friends_test.go
@@ -20,7 +20,6 @@ const (
 	peopleHubSocialURL    = "https://peoplehub.xboxlive.com/users/me/people/social"
 	pendingRequestsURL    = "https://peoplehub.xboxlive.com/users/me/people/friendRequests(received)"
 	bulkAddFriendsURL     = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
-	socialSummaryURL      = "https://social.xboxlive.com/users/me/summary"
 )
 
 func followURL(xuid string) string {
@@ -323,24 +322,6 @@ func TestFriendClientForceUnfollowDeletesFollowerRelationship(t *testing.T) {
 	}
 	if !called {
 		t.Fatal("client was not called")
-	}
-}
-
-func TestFriendClientSummaryReturnsFollowingCount(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != socialSummaryURL {
-				t.Fatalf("unexpected URL %s", req.URL)
-			}
-			return response(http.StatusOK, `{"targetFollowingCount":1337,"targetFollowerCount":42}`), nil
-		})},
-	}
-	summary, err := client.Summary(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if summary.TargetFollowingCount != 1337 || summary.TargetFollowerCount != 42 {
-		t.Fatalf("summary = %#v", summary)
 	}
 }
 

--- a/friends_test.go
+++ b/friends_test.go
@@ -19,7 +19,7 @@ const (
 	peopleHubFollowersURL = "https://peoplehub.xboxlive.com/users/me/people/followers"
 	peopleHubSocialURL    = "https://peoplehub.xboxlive.com/users/me/people/social"
 	pendingRequestsURL    = "https://peoplehub.xboxlive.com/users/me/people/friendRequests(received)"
-	bulkAddFriendsURL     = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
+	addFriendsURL         = "https://social.xboxlive.com/bulk/users/me/people/friends/v2?method=add"
 )
 
 func followURL(xuid string) string {
@@ -200,7 +200,7 @@ func TestFriendClientFollowReturnsSocialResponseErrors(t *testing.T) {
 	}
 }
 
-func TestFriendClientAcceptPendingFriendRequestsUsesBulkAdd(t *testing.T) {
+func TestFriendClientAcceptPendingFriendRequestsUsesAddFriends(t *testing.T) {
 	var requests []string
 	client := FriendClient{
 		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -214,7 +214,7 @@ func TestFriendClientAcceptPendingFriendRequestsUsesBulkAdd(t *testing.T) {
 					t.Fatalf("contract version = %q, want 7", req.Header.Get("X-Xbl-Contract-Version"))
 				}
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"},{"xuid":"2","gamertag":"Two"}]}`), nil
-			case req.Method == http.MethodPost && req.URL.String() == bulkAddFriendsURL:
+			case req.Method == http.MethodPost && req.URL.String() == addFriendsURL:
 				body, err := io.ReadAll(req.Body)
 				if err != nil {
 					t.Fatal(err)
@@ -235,7 +235,7 @@ func TestFriendClientAcceptPendingFriendRequestsUsesBulkAdd(t *testing.T) {
 	}
 	wantRequests := strings.Join([]string{
 		http.MethodGet + " " + pendingRequestsURL,
-		http.MethodPost + " " + bulkAddFriendsURL,
+		http.MethodPost + " " + addFriendsURL,
 	}, ",")
 	if got := strings.Join(requests, ","); got != wantRequests {
 		t.Fatalf("requests = %s, want %s", got, wantRequests)

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260714002042-493db599d497
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702144042-a3be892e6790
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702144042-a3be892e6790 h1:ci2oUIiJ0jDU44FETMM6B39IptgbPv0TSSaTcnbKIMg=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260702144042-a3be892e6790/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5 h1:m/bwofpyFmleeDFtuzn5bBGwgLwzXVdGU6cqznTo09w=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=


### PR DESCRIPTION
## Summary

- update the Lunar go-xsapi fork pin after merging current upstream
- migrate bulk friend acceptance from `BulkAddFriends` to `AddFriends`
- remove the unused social summary wrapper and test after upstream removed that API

## Why

Upstream consolidated the RTA provider API, renamed the bulk friend method, and removed the social summary API. The broadcaster already counts friends from `Friends()` because `targetFollowingCount` is unreliable, so the summary wrapper was dead code.

## Validation

- `go test ./...`
- `go vet ./...`
- dependency-only red run failed at the three removed/renamed symbols before the source migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the friend summary feature and its associated test coverage.
  * Updated pending friend request acceptance to use the current social-friends operation.
  * Updated the underlying service integration to a newer implementation version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->