### PR TITLE
Preserve downstream go-xsapi compatibility

### DIFF
--- a/friends.go
+++ b/friends.go
@@ -81,7 +81,7 @@ func (c FriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person
 		return nil, nil
 	}
 
-	updatedXUIDs, err := socialClient.AddFriends(ctx, xuids)
+	updatedXUIDs, err := socialClient.BulkAddFriends(ctx, xuids)
 	if err != nil {
 		return nil, err
 	}

--- a/friends_test.go
+++ b/friends_test.go
@@ -200,7 +200,7 @@ func TestFriendClientFollowReturnsSocialResponseErrors(t *testing.T) {
 	}
 }
 
-func TestFriendClientAcceptPendingFriendRequestsUsesAddFriends(t *testing.T) {
+func TestFriendClientAcceptPendingFriendRequestsUsesBulkAddFriends(t *testing.T) {
 	var requests []string
 	client := FriendClient{
 		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260714002042-493db599d497
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718024334-12d1f14136c3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5 h1:m/bwofpyFmleeDFtuzn5bBGwgLwzXVdGU6cqznTo09w=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718022705-b9ec10b746d5/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718024334-12d1f14136c3 h1:gm7WFuOWRPQTwryOp21OHXSZPaayHvofBsg+mSeQex4=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260718024334-12d1f14136c3/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=


### PR DESCRIPTION
Follow-up to #16.

- Retains the deprecated `BulkAddFriends` compatibility surface in the go-xsapi fork while upstream exposes `AddFriends`.
- Keeps go-mcxboxbroadcast compilable for downstream consumers, because dependency `replace` directives are not inherited.
- Pins the fork commit containing the compatibility alias and regression test.

Validated with `go test ./...`, `go vet ./...`, focused social tests, and a compile using an alternate modfile with the go-xsapi replace removed.