### PR TITLE
broadcaster.go: Added Invite method to Broadcaster

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -588,6 +588,20 @@ func (i *subAccountInviter) Invite(ctx context.Context, xuid, titleID string) er
 	return err
 }
 
+// Invite sends a game invite to xuid through the broadcaster's active MPSD session.
+func (b *Broadcaster) Invite(ctx context.Context, xuid, titleID string) error {
+	b.mu.Lock()
+	announcer, ok := xblAnnouncer(b.announcer)
+	if !ok || announcer.Session == nil {
+		b.mu.Unlock()
+		return errors.New("invite: no active MPSD session")
+	}
+	session := announcer.Session
+	b.mu.Unlock()
+	_, err := session.Invite(ctx, xuid, titleID)
+	return err
+}
+
 // loggingAnnouncer wraps an announcer with debug-level status logging.
 type loggingAnnouncer struct {
 	room.Announcer

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -559,13 +560,22 @@ type broadcasterInviter struct {
 // Invite snapshots the active MPSD session under the mutex and sends a game invite.
 func (i *broadcasterInviter) Invite(ctx context.Context, xuid, titleID string) error {
 	i.b.mu.Lock()
+	if !i.b.started {
+		i.b.mu.Unlock()
+		return errors.New("invite: broadcaster not started")
+	}
 	announcer, ok := xblAnnouncer(i.b.announcer)
-	if !ok || announcer.Session == nil {
+	if !ok {
 		i.b.mu.Unlock()
 		return errors.New("invite: no active MPSD session")
 	}
+	announcer.Lock()
 	session := announcer.Session
+	announcer.Unlock()
 	i.b.mu.Unlock()
+	if session == nil || session.Context().Err() != nil {
+		return errors.New("invite: no active MPSD session")
+	}
 	_, err := session.Invite(ctx, xuid, titleID)
 	return err
 }
@@ -588,18 +598,10 @@ func (i *subAccountInviter) Invite(ctx context.Context, xuid, titleID string) er
 	return err
 }
 
-// Invite sends a game invite to xuid through the broadcaster's active MPSD session.
-func (b *Broadcaster) Invite(ctx context.Context, xuid, titleID string) error {
-	b.mu.Lock()
-	announcer, ok := xblAnnouncer(b.announcer)
-	if !ok || announcer.Session == nil {
-		b.mu.Unlock()
-		return errors.New("invite: no active MPSD session")
-	}
-	session := announcer.Session
-	b.mu.Unlock()
-	_, err := session.Invite(ctx, xuid, titleID)
-	return err
+// Invite sends a Minecraft game invite to xuid through the broadcaster's
+// active MPSD session.
+func (b *Broadcaster) Invite(ctx context.Context, xuid string) error {
+	return (&broadcasterInviter{b: b}).Invite(ctx, xuid, strconv.FormatInt(TitleID, 10))
 }
 
 // loggingAnnouncer wraps an announcer with debug-level status logging.

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -299,6 +299,20 @@ func TestXBLAnnouncerUnwrapsDiagnosticsWrappers(t *testing.T) {
 	}
 }
 
+func TestBroadcasterInviteRequiresActiveBroadcaster(t *testing.T) {
+	// Keep the public API Minecraft-specific: callers provide only the XUID,
+	// while Broadcaster supplies the package's title ID.
+	var invite func(*Broadcaster, context.Context, string) error = (*Broadcaster).Invite
+
+	b := &Broadcaster{
+		announcer: &room.XBLAnnouncer{Session: &mpsd.Session{}},
+	}
+	err := invite(b, context.Background(), "456")
+	if err == nil || !strings.Contains(err.Error(), "broadcaster not started") {
+		t.Fatalf("Invite error = %v, want broadcaster-not-started error", err)
+	}
+}
+
 func TestBroadcasterWarnsForWebSocketSignaling(t *testing.T) {
 	var log bytes.Buffer
 	b := &Broadcaster{log: slog.New(slog.NewTextHandler(&log, nil))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sending invitations through the broadcaster’s active session.
  - Invitations now return a clear error when no active session is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->