### PR TITLE
Add configurable ICE UDP port range

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -15,6 +15,10 @@ session:
   configFallback: false
   broadcastSetting: 3
   worldType: Survival
+  # Set both to 0 to use the operating system's full ephemeral UDP range.
+  icePortRange:
+    min: 0
+    max: 0
   sessionInfo:
     hostName: Minecraft Server
     worldName: Minecraft World

--- a/config_file.go
+++ b/config_file.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/df-mc/go-nethernet"
 	"github.com/df-mc/go-xsapi/v2"
 	"github.com/pelletier/go-toml/v2"
+	"github.com/pion/webrtc/v4"
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/service"
 	"gopkg.in/yaml.v3"
@@ -44,14 +46,20 @@ type HTTPFileConfig struct {
 // The Geyser-extension-only remoteAddress/remotePort keys are intentionally
 // absent; the broadcast target always comes from sessionInfo.
 type SessionFileConfig struct {
-	UpdateInterval   int             `yaml:"updateInterval" toml:"updateInterval"`
-	SignalingMode    string          `yaml:"signalingMode" toml:"signalingMode"`
-	QueryServer      bool            `yaml:"queryServer" toml:"queryServer"`
-	WebQueryFallback bool            `yaml:"webQueryFallback" toml:"webQueryFallback"`
-	ConfigFallback   bool            `yaml:"configFallback" toml:"configFallback"`
-	BroadcastSetting int32           `yaml:"broadcastSetting" toml:"broadcastSetting"`
-	WorldType        string          `yaml:"worldType" toml:"worldType"`
-	SessionInfo      SessionInfoFile `yaml:"sessionInfo" toml:"sessionInfo"`
+	UpdateInterval   int              `yaml:"updateInterval" toml:"updateInterval"`
+	SignalingMode    string           `yaml:"signalingMode" toml:"signalingMode"`
+	QueryServer      bool             `yaml:"queryServer" toml:"queryServer"`
+	WebQueryFallback bool             `yaml:"webQueryFallback" toml:"webQueryFallback"`
+	ConfigFallback   bool             `yaml:"configFallback" toml:"configFallback"`
+	BroadcastSetting int32            `yaml:"broadcastSetting" toml:"broadcastSetting"`
+	WorldType        string           `yaml:"worldType" toml:"worldType"`
+	ICEPortRange     ICEPortRangeFile `yaml:"icePortRange" toml:"icePortRange"`
+	SessionInfo      SessionInfoFile  `yaml:"sessionInfo" toml:"sessionInfo"`
+}
+
+type ICEPortRangeFile struct {
+	Min int `yaml:"min" toml:"min"`
+	Max int `yaml:"max" toml:"max"`
 }
 
 type SessionInfoFile struct {
@@ -274,6 +282,10 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	netherNetListenConfig, err := c.Session.ICEPortRange.listenConfig()
+	if err != nil {
+		return Config{}, err
+	}
 	cfg := Config{
 		XBLClient:            in.XBLClient,
 		XBLTokenSource:       in.XBLTokenSource,
@@ -297,6 +309,7 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 		ListenConfig: minecraft.ListenConfig{
 			HTTPClient: in.HTTPClient,
 		},
+		NetherNetListenConfig:        netherNetListenConfig,
 		UpdateInterval:               time.Duration(c.Session.UpdateInterval) * time.Second,
 		HTTPClient:                   in.HTTPClient,
 		Log:                          in.Log,
@@ -322,6 +335,23 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+func (r ICEPortRangeFile) listenConfig() (nethernet.ListenConfig, error) {
+	if r.Min == 0 && r.Max == 0 {
+		return nethernet.ListenConfig{}, nil
+	}
+	if r.Min < 1 || r.Max < 1 || r.Min > 65535 || r.Max > 65535 || r.Min > r.Max {
+		return nethernet.ListenConfig{}, fmt.Errorf(
+			"session.icePortRange must be disabled with min/max 0 or satisfy 1 <= min <= max <= 65535 (got min=%d max=%d)",
+			r.Min, r.Max,
+		)
+	}
+	var settingEngine webrtc.SettingEngine
+	if err := settingEngine.SetEphemeralUDPPortRange(uint16(r.Min), uint16(r.Max)); err != nil {
+		return nethernet.ListenConfig{}, fmt.Errorf("configure session.icePortRange: %w", err)
+	}
+	return nethernet.ListenConfig{API: webrtc.NewAPI(webrtc.WithSettingEngine(settingEngine))}, nil
 }
 
 func configSignalingMode(mode string) (SignalingMode, error) {

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -252,6 +252,55 @@ func TestConfigFileMapsSuppressSessionUpdateMessage(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigMapsICEUDPPortRange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(path, []byte(`
+session:
+  icePortRange:
+    min: 40000
+    max: 40010
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.NetherNetListenConfig.API == nil {
+		t.Fatal("configured ICE UDP port range did not create a WebRTC API")
+	}
+}
+
+func TestRuntimeConfigRejectsInvalidICEUDPPortRange(t *testing.T) {
+	tests := map[string]string{
+		"missing maximum": "min: 40000\n    max: 0",
+		"missing minimum": "min: 0\n    max: 40010",
+		"reversed":        "min: 40010\n    max: 40000",
+		"negative":        "min: -1\n    max: 40000",
+		"too large":       "min: 40000\n    max: 65536",
+	}
+	for name, ports := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yml")
+			data := "session:\n  icePortRange:\n    " + ports + "\n"
+			if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadConfigFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}}); err == nil {
+				t.Fatal("expected invalid ICE UDP port range error")
+			}
+		})
+	}
+}
+
 func TestConfigFileRejectsWebSocketSignalingMode(t *testing.T) {
 	cfg := DefaultConfigFile()
 	cfg.Session.SignalingMode = "websocket"

--- a/deployments/pterodactyl/egg-go-mcxboxbroadcast.json
+++ b/deployments/pterodactyl/egg-go-mcxboxbroadcast.json
@@ -15,14 +15,14 @@
     "file_denylist": [],
     "startup": "/mcxboxbroadcast -config /home/container/config.yml",
     "config": {
-        "files": "{\n    \"config.yml\": {\n        \"parser\": \"yaml\",\n        \"find\": {\n            \"debugMode\": \"{{server.build.env.DEBUG_MODE}}\",\n            \"session.queryServer\": \"{{server.build.env.QUERY_SERVER}}\",\n            \"session.configFallback\": \"{{server.build.env.CONFIG_FALLBACK}}\",\n            \"session.sessionInfo.hostName\": \"{{server.build.env.HOST_NAME}}\",\n            \"session.sessionInfo.worldName\": \"{{server.build.env.WORLD_NAME}}\",\n            \"session.sessionInfo.maxPlayers\": \"{{server.build.env.MAX_PLAYERS}}\",\n            \"session.sessionInfo.ip\": \"{{server.build.env.TARGET_SERVER_HOST}}\",\n            \"session.sessionInfo.port\": \"{{server.build.env.TARGET_SERVER_PORT}}\",\n            \"notifications.enabled\": \"{{server.build.env.NOTIFICATIONS_ENABLED}}\",\n            \"notifications.webhookUrl\": \"{{server.build.env.WEBHOOK_URL}}\",\n            \"gallery.enabled\": \"{{server.build.env.GALLERY_ENABLED}}\",\n            \"gallery.imagePath\": \"{{server.build.env.GALLERY_IMAGE_PATH}}\"\n        }\n    }\n}",
+        "files": "{\n    \"config.yml\": {\n        \"parser\": \"yaml\",\n        \"find\": {\n            \"debugMode\": \"{{server.build.env.DEBUG_MODE}}\",\n            \"session.queryServer\": \"{{server.build.env.QUERY_SERVER}}\",\n            \"session.configFallback\": \"{{server.build.env.CONFIG_FALLBACK}}\",\n            \"session.icePortRange.min\": \"{{server.build.env.ICE_PORT_MIN}}\",\n            \"session.icePortRange.max\": \"{{server.build.env.ICE_PORT_MAX}}\",\n            \"session.sessionInfo.hostName\": \"{{server.build.env.HOST_NAME}}\",\n            \"session.sessionInfo.worldName\": \"{{server.build.env.WORLD_NAME}}\",\n            \"session.sessionInfo.maxPlayers\": \"{{server.build.env.MAX_PLAYERS}}\",\n            \"session.sessionInfo.ip\": \"{{server.build.env.TARGET_SERVER_HOST}}\",\n            \"session.sessionInfo.port\": \"{{server.build.env.TARGET_SERVER_PORT}}\",\n            \"notifications.enabled\": \"{{server.build.env.NOTIFICATIONS_ENABLED}}\",\n            \"notifications.webhookUrl\": \"{{server.build.env.WEBHOOK_URL}}\",\n            \"gallery.enabled\": \"{{server.build.env.GALLERY_ENABLED}}\",\n            \"gallery.imagePath\": \"{{server.build.env.GALLERY_IMAGE_PATH}}\"\n        }\n    }\n}",
         "startup": "{\n    \"done\": \"broadcasting\"\n}",
         "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!/bin/ash\nset -eu\n\ncd /mnt/server\nmkdir -p cache\n\nif [ ! -f config.yml ]; then\n    cat > config.yml <<EOF\nconfigVersion: 3\ndebugMode: ${DEBUG_MODE}\nsuppressSessionUpdateMessage: false\n\nhttp:\n  proxy: \"\"\n\nsession:\n  updateInterval: 30\n  signalingMode: jsonrpc\n  queryServer: ${QUERY_SERVER}\n  webQueryFallback: false\n  configFallback: ${CONFIG_FALLBACK}\n  broadcastSetting: 3\n  worldType: Survival\n  sessionInfo:\n    hostName: \"${HOST_NAME}\"\n    worldName: \"${WORLD_NAME}\"\n    players: 0\n    maxPlayers: ${MAX_PLAYERS}\n    ip: \"${TARGET_SERVER_HOST}\"\n    port: ${TARGET_SERVER_PORT}\n\nfriendSync:\n  updateInterval: 60\n  autoFollow: true\n  autoUnfollow: true\n  initialInvite: true\n  expiry:\n    enabled: true\n    days: 15\n    check: 1800\n    historyPath: cache/player_history.json\n\nnotifications:\n  enabled: ${NOTIFICATIONS_ENABLED}\n  webhookUrl: \"${WEBHOOK_URL}\"\n\ngallery:\n  enabled: ${GALLERY_ENABLED}\n  imagePath: \"${GALLERY_IMAGE_PATH}\"\n  deleteOtherImages: true\n\naccounts:\n  primaryCachePath: cache/live_token.json\n  subAccounts: []\nEOF\nfi\n\necho \"go-mcxboxbroadcast configuration is ready. Start the server and complete the Microsoft device-code sign-in shown in the console.\"\n",
+            "script": "#!/bin/ash\nset -eu\n\ncd /mnt/server\nmkdir -p cache\n\nif [ ! -f config.yml ]; then\n    cat > config.yml <<EOF\nconfigVersion: 3\ndebugMode: ${DEBUG_MODE}\nsuppressSessionUpdateMessage: false\n\nhttp:\n  proxy: \"\"\n\nsession:\n  updateInterval: 30\n  signalingMode: jsonrpc\n  queryServer: ${QUERY_SERVER}\n  webQueryFallback: false\n  configFallback: ${CONFIG_FALLBACK}\n  broadcastSetting: 3\n  worldType: Survival\n  icePortRange:\n    min: ${ICE_PORT_MIN}\n    max: ${ICE_PORT_MAX}\n  sessionInfo:\n    hostName: \"${HOST_NAME}\"\n    worldName: \"${WORLD_NAME}\"\n    players: 0\n    maxPlayers: ${MAX_PLAYERS}\n    ip: \"${TARGET_SERVER_HOST}\"\n    port: ${TARGET_SERVER_PORT}\n\nfriendSync:\n  updateInterval: 60\n  autoFollow: true\n  autoUnfollow: true\n  initialInvite: true\n  expiry:\n    enabled: true\n    days: 15\n    check: 1800\n    historyPath: cache/player_history.json\n\nnotifications:\n  enabled: ${NOTIFICATIONS_ENABLED}\n  webhookUrl: \"${WEBHOOK_URL}\"\n\ngallery:\n  enabled: ${GALLERY_ENABLED}\n  imagePath: \"${GALLERY_IMAGE_PATH}\"\n  deleteOtherImages: true\n\naccounts:\n  primaryCachePath: cache/live_token.json\n  subAccounts: []\nEOF\nfi\n\necho \"go-mcxboxbroadcast configuration is ready. Start the server and complete the Microsoft device-code sign-in shown in the console.\"\n",
             "container": "ghcr.io/pterodactyl/installers:alpine",
             "entrypoint": "ash"
         }
@@ -46,6 +46,26 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|integer|between:1,65535",
+            "field_type": "text"
+        },
+        {
+            "name": "ICE UDP Port Minimum",
+            "description": "Lowest UDP port NetherNet may allocate for WebRTC. Set both ICE port values to 0 to use the operating system ephemeral range.",
+            "env_variable": "ICE_PORT_MIN",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:0,65535",
+            "field_type": "text"
+        },
+        {
+            "name": "ICE UDP Port Maximum",
+            "description": "Highest UDP port NetherNet may allocate for WebRTC. Set both ICE port values to 0 to use the operating system ephemeral range.",
+            "env_variable": "ICE_PORT_MAX",
+            "default_value": "0",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|integer|between:0,65535",
             "field_type": "text"
         },
         {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lmittmann/tint v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/pion/webrtc/v4 v4.2.16-0.20260627075746-7a223a6f4d4f
 	github.com/sandertv/go-raknet v1.15.1
 	github.com/sandertv/gophertunnel v0.0.0-00010101000000-000000000000
 	golang.org/x/oauth2 v0.36.0
@@ -40,7 +41,6 @@ require (
 	github.com/pion/stun/v3 v3.1.6 // indirect
 	github.com/pion/transport/v4 v4.0.2 // indirect
 	github.com/pion/turn/v5 v5.0.10 // indirect
-	github.com/pion/webrtc/v4 v4.2.16-0.20260627075746-7a223a6f4d4f // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect

--- a/pterodactyl_test.go
+++ b/pterodactyl_test.go
@@ -28,6 +28,7 @@ func TestPterodactylArtifacts(t *testing.T) {
 		} `json:"config"`
 		Scripts struct {
 			Installation struct {
+				Script     string `json:"script"`
 				Container  string `json:"container"`
 				Entrypoint string `json:"entrypoint"`
 			} `json:"installation"`
@@ -71,13 +72,28 @@ func TestPterodactylArtifacts(t *testing.T) {
 		}
 	}
 
-	var seenTargetHost, seenTargetPort bool
+	var seenTargetHost, seenTargetPort, seenICEPortMin, seenICEPortMax bool
 	for _, variable := range egg.Variables {
 		seenTargetHost = seenTargetHost || variable.EnvVariable == "TARGET_SERVER_HOST"
 		seenTargetPort = seenTargetPort || variable.EnvVariable == "TARGET_SERVER_PORT"
+		seenICEPortMin = seenICEPortMin || variable.EnvVariable == "ICE_PORT_MIN"
+		seenICEPortMax = seenICEPortMax || variable.EnvVariable == "ICE_PORT_MAX"
 	}
 	if !seenTargetHost || !seenTargetPort {
 		t.Fatalf("target server variables missing: host=%v port=%v", seenTargetHost, seenTargetPort)
+	}
+	if !seenICEPortMin || !seenICEPortMax {
+		t.Fatalf("ICE port variables missing: min=%v max=%v", seenICEPortMin, seenICEPortMax)
+	}
+	for _, want := range []string{"ICE_PORT_MIN", "ICE_PORT_MAX", "session.icePortRange.min", "session.icePortRange.max"} {
+		if !strings.Contains(egg.Config.Files, want) {
+			t.Fatalf("config.files does not contain %q", want)
+		}
+	}
+	for _, want := range []string{"icePortRange:", "${ICE_PORT_MIN}", "${ICE_PORT_MAX}"} {
+		if !strings.Contains(egg.Scripts.Installation.Script, want) {
+			t.Fatalf("installation script does not contain %q", want)
+		}
 	}
 
 	dockerfile, err := os.ReadFile("Dockerfile")


### PR DESCRIPTION
## Summary

- add session.icePortRange configuration for NetherNet WebRTC
- validate disabled and bounded UDP ranges before startup
- expose ICE port bounds in the Pterodactyl egg

## Why

Operators behind Docker, Kubernetes, or restrictive firewalls need a predictable UDP allocation range for incoming NetherNet connections.

## Validation

- go test ./... -count=1
- go test -race ./... -count=1
- go vet ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable WebRTC ICE UDP port ranges for session networking.
  * Port ranges can use the full operating system range by setting both values to `0`.
  * Added Pterodactyl deployment variables for configuring minimum and maximum ICE UDP ports.

* **Bug Fixes**
  * Added validation for missing, reversed, negative, and out-of-range port values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->