### PR TITLE
Bound background Xbox operations

### DIFF
--- a/friend_sync.go
+++ b/friend_sync.go
@@ -125,7 +125,9 @@ func (s FriendSyncer) syncWithOptions(ctx context.Context, opts friendSyncOption
 	if s.Config.AutoFollow && opts.autoFollow {
 		s.acceptPending(ctx, &result)
 	}
-	people, err := s.Client.Friends(ctx)
+	operationCtx, cancel := xboxOperationContext(ctx)
+	people, err := s.Client.Friends(operationCtx)
+	cancel()
 	if err != nil {
 		return result, err
 	}
@@ -198,7 +200,9 @@ func (s FriendSyncer) acceptPending(ctx context.Context, result *friendSyncResul
 		return
 	}
 	s.debug(ctx, "accepting pending friend requests")
-	accepted, err := accepter.AcceptPendingFriendRequests(ctx)
+	operationCtx, cancel := xboxOperationContext(ctx)
+	accepted, err := accepter.AcceptPendingFriendRequests(operationCtx)
+	cancel()
 	for _, p := range accepted {
 		s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag, "source", "pending_requests")
 	}
@@ -218,7 +222,9 @@ func (s FriendSyncer) acceptPending(ctx context.Context, result *friendSyncResul
 // follow follows p back and reports whether the friendship was established.
 // Restricted accounts are force-unfollowed so they are not retried forever.
 func (s FriendSyncer) follow(ctx context.Context, p Person, result *friendSyncResult) bool {
-	err := s.Client.Follow(ctx, p.XUID)
+	operationCtx, cancel := xboxOperationContext(ctx)
+	err := s.Client.Follow(operationCtx, p.XUID)
+	cancel()
 	if err == nil {
 		s.info(ctx, "added friend", "xuid", p.XUID, "gamertag", p.Gamertag)
 		if s.Config.InitialInvite && s.Inviter != nil {
@@ -248,7 +254,10 @@ func (s FriendSyncer) dropRestrictedFollower(ctx context.Context, p Person) {
 	if !ok {
 		return
 	}
-	if err := unfollower.ForceUnfollow(ctx, p.XUID); err != nil {
+	operationCtx, cancel := xboxOperationContext(ctx)
+	err := unfollower.ForceUnfollow(operationCtx, p.XUID)
+	cancel()
+	if err != nil {
 		if s.Log != nil {
 			s.Log.Error("force unfollow restricted account", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
 		}
@@ -263,7 +272,10 @@ func (s FriendSyncer) dropRestrictedFollower(ctx context.Context, p Person) {
 
 // unfollow removes p and reports whether the removal succeeded.
 func (s FriendSyncer) unfollow(ctx context.Context, p Person, reason string, result *friendSyncResult) bool {
-	if err := s.Client.Unfollow(ctx, p.XUID); err != nil {
+	operationCtx, cancel := xboxOperationContext(ctx)
+	err := s.Client.Unfollow(operationCtx, p.XUID)
+	cancel()
+	if err != nil {
 		s.debug(ctx, "failed to remove friend", "xuid", p.XUID, "gamertag", p.Gamertag, "err", err)
 		if delay := retryDelay(err); delay > 0 {
 			result.unfollowRetryAfter = delay
@@ -344,7 +356,10 @@ func (s FriendSyncer) pruneHistory(ctx context.Context, people []Person) {
 
 func (s FriendSyncer) sendInitialInvite(ctx context.Context, p Person, source string) {
 	s.debug(ctx, "sending initial invite", "xuid", p.XUID, "gamertag", p.Gamertag, "source", source)
-	if err := s.Inviter.Invite(ctx, p.XUID, strconv.FormatInt(TitleID, 10)); err != nil {
+	operationCtx, cancel := xboxOperationContext(ctx)
+	err := s.Inviter.Invite(operationCtx, p.XUID, strconv.FormatInt(TitleID, 10))
+	cancel()
+	if err != nil {
 		if s.Log != nil {
 			s.Log.Warn("send initial invite", "xuid", p.XUID, "gamertag", p.Gamertag, "source", source, "err", err)
 		}

--- a/friend_sync_test.go
+++ b/friend_sync_test.go
@@ -43,6 +43,30 @@ func TestFriendSyncerAcceptsPendingIncomingRequests(t *testing.T) {
 	}
 }
 
+func TestFriendSyncerBoundsXboxOperations(t *testing.T) {
+	client := &deadlineFriendClient{}
+	syncer := FriendSyncer{
+		Client: client,
+		Config: FriendSyncConfig{
+			AutoFollow:    true,
+			AutoUnfollow:  true,
+			InitialInvite: true,
+		},
+		Inviter: deadlineInviter{record: client.record},
+	}
+	if err := syncer.Sync(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []string{"accept", "friends", "follow", "unfollow", "force_unfollow", "invite"} {
+		if !client.called[operation] {
+			t.Fatalf("%s was not called", operation)
+		}
+		if !client.deadlined[operation] {
+			t.Fatalf("%s did not receive a bounded context", operation)
+		}
+	}
+}
+
 func TestFriendSyncerContinuesAutoFollowWhenPendingAcceptFails(t *testing.T) {
 	acceptErr := errors.New("pending requests unavailable")
 	client := syncFriendClient{
@@ -382,6 +406,62 @@ type syncFriendClient struct {
 	followCalls     int
 	removeCalls     int
 	forceUnfollowed []string
+}
+
+type deadlineFriendClient struct {
+	called    map[string]bool
+	deadlined map[string]bool
+}
+
+func (c *deadlineFriendClient) record(operation string, ctx context.Context) {
+	if c.called == nil {
+		c.called = map[string]bool{}
+		c.deadlined = map[string]bool{}
+	}
+	c.called[operation] = true
+	deadline, ok := ctx.Deadline()
+	c.deadlined[operation] = ok && time.Until(deadline) > 0 && time.Until(deadline) <= 20*time.Second
+}
+
+func (c *deadlineFriendClient) Friends(ctx context.Context) ([]Person, error) {
+	c.record("friends", ctx)
+	return []Person{
+		{XUID: "follow", Gamertag: "Follow", IsFollowingCaller: true},
+		{XUID: "restricted", Gamertag: "Restricted", IsFollowingCaller: true},
+		{XUID: "unfollow", Gamertag: "Unfollow", IsFollowedByCaller: true},
+	}, nil
+}
+
+func (c *deadlineFriendClient) Follow(ctx context.Context, xuid string) error {
+	c.record("follow", ctx)
+	if xuid == "restricted" {
+		return xblsocial.ErrFriendRestricted
+	}
+	return nil
+}
+
+func (c *deadlineFriendClient) Unfollow(ctx context.Context, _ string) error {
+	c.record("unfollow", ctx)
+	return nil
+}
+
+func (c *deadlineFriendClient) ForceUnfollow(ctx context.Context, _ string) error {
+	c.record("force_unfollow", ctx)
+	return nil
+}
+
+func (c *deadlineFriendClient) AcceptPendingFriendRequests(ctx context.Context) ([]Person, error) {
+	c.record("accept", ctx)
+	return []Person{{XUID: "pending", Gamertag: "Pending"}}, nil
+}
+
+type deadlineInviter struct {
+	record func(string, context.Context)
+}
+
+func (i deadlineInviter) Invite(ctx context.Context, _, _ string) error {
+	i.record("invite", ctx)
+	return nil
 }
 
 func (c *syncFriendClient) ForceUnfollow(_ context.Context, xuid string) error {

--- a/presence.go
+++ b/presence.go
@@ -30,7 +30,9 @@ func (c PresenceClient) Update(ctx context.Context) (time.Duration, error) {
 		return defaultPresenceHeartbeat, errors.New("xuid is empty")
 	}
 	presenceClient := presence.New(c.client(), xsts.UserInfo{XUID: c.XUID})
-	result, err := presenceClient.Update(ctx, presence.TitleRequest{State: presence.StateActive})
+	operationCtx, cancel := xboxOperationContext(ctx)
+	result, err := presenceClient.Update(operationCtx, presence.TitleRequest{State: presence.StateActive})
+	cancel()
 	if err != nil {
 		return defaultPresenceHeartbeat, err
 	}

--- a/presence_test.go
+++ b/presence_test.go
@@ -83,6 +83,26 @@ func TestPresenceClientUpdateDefaultsHeartbeatWhenHeaderInvalid(t *testing.T) {
 	}
 }
 
+func TestPresenceClientUpdateBoundsRequestContext(t *testing.T) {
+	client := PresenceClient{
+		XUID: "1",
+		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			deadline, ok := req.Context().Deadline()
+			if !ok {
+				t.Fatal("presence request has no deadline")
+			}
+			remaining := time.Until(deadline)
+			if remaining <= 0 || remaining > 20*time.Second {
+				t.Fatalf("presence request deadline remaining = %s", remaining)
+			}
+			return response(http.StatusOK, ""), nil
+		})},
+	}
+	if _, err := client.Update(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPresenceClientUpdateRejectsEmptyXUID(t *testing.T) {
 	client := PresenceClient{}
 

--- a/xbox_operation.go
+++ b/xbox_operation.go
@@ -1,0 +1,17 @@
+package broadcaster
+
+import (
+	"context"
+	"time"
+)
+
+const defaultXboxOperationTimeout = 15 * time.Second
+
+// xboxOperationContext bounds one background Xbox API operation without
+// imposing the same deadline on an entire sync pass or broadcaster lifetime.
+func xboxOperationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, defaultXboxOperationTimeout)
+}


### PR DESCRIPTION
## Summary

- apply a fresh 15-second context to each background Xbox operation
- cover friend scans and mutations, pending requests, restricted-follower cleanup, initial invites, and presence updates
- preserve shorter caller deadlines and avoid imposing a global HTTP timeout on auth or gallery paths

## Why

The broadcaster previously passed its process-lifetime context into several background APIs. A stalled request could permanently wedge a friend-sync or presence worker.

## Validation

- go test ./... -count=1
- go test -race ./... -count=1
- go vet ./...
- git diff --check