### PR TITLE
Upload gallery images for subaccounts

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -52,15 +52,17 @@ type Broadcaster struct {
 	subAccountPublisher func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error)
 	xblClient           *xsapi.Client
 	minecraftTokens     service.TokenSource
+	subMinecraftTokens  map[*xsapi.Client]service.TokenSource
 	createdXBLClients   []*xsapi.Client
 
 	ctx    context.Context
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	mu       sync.Mutex
-	started  bool
-	acceptWg sync.WaitGroup
+	mu        sync.Mutex
+	galleryMu sync.Mutex
+	started   bool
+	acceptWg  sync.WaitGroup
 
 	// lastQuery is the most recent successful target-server query, kept so
 	// query failures fall back to real data instead of failing the update.
@@ -1031,8 +1033,12 @@ func subAccountFollowState(ctx context.Context, sub FriendClient, primaryXUID st
 	return false, false
 }
 
-// uploadGallery uploads the configured showcase image to the Xbox gallery.
+// uploadGallery uploads the configured showcase image for the primary account
+// and each enabled sub-account. Accounts fail independently.
 func (b *Broadcaster) uploadGallery(ctx context.Context) {
+	b.galleryMu.Lock()
+	defer b.galleryMu.Unlock()
+
 	cfg := b.conf.Gallery
 	if cfg == nil || !cfg.Enabled {
 		return
@@ -1046,31 +1052,85 @@ func (b *Broadcaster) uploadGallery(ctx context.Context) {
 		if err != nil {
 			b.log.Warn("minecraft services token source unavailable", "err", err)
 			b.notify(ctx, "Showcase image upload skipped: Minecraft services token source is unavailable.")
-			return
+		} else {
+			src = tokens
 		}
-		src = tokens
 	}
-	xuid := b.primaryXUID()
-	if xuid == "" {
-		b.log.Warn("gallery skipped because token XUID is empty")
-		b.notify(ctx, "Showcase image upload skipped: Xbox profile XUID is empty.")
-		return
+	if src != nil {
+		if xuid := b.primaryXUID(); xuid == "" {
+			b.log.Warn("gallery skipped because token XUID is empty")
+			b.notify(ctx, "Showcase image upload skipped: Xbox profile XUID is empty.")
+		} else {
+			b.uploadGalleryAccount(ctx, cfg, "", xuid, src)
+		}
 	}
+
+	for i := range b.conf.SubAccounts {
+		account := &b.conf.SubAccounts[i]
+		if !account.Enabled || !subAccountHasXBLCredentials(*account) {
+			continue
+		}
+		xuid := accountXUID(*account)
+		if xuid == "" {
+			b.log.Warn("sub-account gallery skipped because xuid is empty", "sub_account", account.ID)
+			continue
+		}
+		src, err := b.subAccountMinecraftTokenSource(b.sharedTokenSourceContext(ctx), account)
+		if err != nil {
+			b.log.Warn("sub-account minecraft services token source unavailable", "sub_account", account.ID, "err", err)
+			b.notify(ctx, "Showcase image upload skipped for sub-account "+account.ID+": Minecraft services token source is unavailable.")
+			continue
+		}
+		b.uploadGalleryAccount(ctx, cfg, account.ID, xuid, src)
+	}
+}
+
+func (b *Broadcaster) uploadGalleryAccount(ctx context.Context, cfg *GalleryConfig, accountID, xuid string, src service.TokenSource) {
 	client := GalleryClient{TokenSource: src, Client: cfg.Client, Log: b.log}
 	if client.Client == nil {
 		client.Client = b.conf.HTTPClient
 	}
-	b.info("setting showcase image", "path", cfg.ImagePath, "delete_other", cfg.DeleteOtherImages)
+	args := []any{"path", cfg.ImagePath, "delete_other", cfg.DeleteOtherImages, "xuid", xuid}
+	if accountID != "" {
+		args = append(args, "sub_account", accountID)
+	}
+	b.info("setting showcase image", args...)
 	result, err := client.SetShowcaseResult(ctx, xuid, cfg.ImagePath, cfg.DeleteOtherImages)
 	if err != nil {
-		b.log.Error("set showcase image", "err", err)
-		b.notify(ctx, "Showcase image upload failed: "+err.Error())
+		b.log.Error("set showcase image", append(args, "err", err)...)
+		if accountID == "" {
+			b.notify(ctx, "Showcase image upload failed: "+err.Error())
+		} else {
+			b.notify(ctx, "Showcase image upload failed for sub-account "+accountID+": "+err.Error())
+		}
 		return
 	}
 	if result.AlreadySet {
-		b.info("showcase image is already set, skipping upload", "image_id", result.ImageID)
+		b.info("showcase image is already set, skipping upload", append(args, "image_id", result.ImageID)...)
 	}
-	b.info("successfully set showcase image", "path", cfg.ImagePath, "image_id", result.ImageID, "uploaded", result.Uploaded)
+	b.info("successfully set showcase image", append(args, "image_id", result.ImageID, "uploaded", result.Uploaded)...)
+}
+
+func (b *Broadcaster) subAccountMinecraftTokenSource(ctx context.Context, account *SubAccountConfig) (service.TokenSource, error) {
+	if account.MinecraftTokenSource != nil {
+		return account.MinecraftTokenSource, nil
+	}
+	client, err := b.subAccountXBLClient(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if tokens := b.subMinecraftTokens[client]; tokens != nil {
+		return tokens, nil
+	}
+	tokens, err := newMinecraftTokenSource(ctx, client, b.conf.HTTPClient, b.log.With("sub_account", account.ID))
+	if err != nil {
+		return nil, err
+	}
+	if b.subMinecraftTokens == nil {
+		b.subMinecraftTokens = make(map[*xsapi.Client]service.TokenSource)
+	}
+	b.subMinecraftTokens[client] = tokens
+	return tokens, nil
 }
 
 // sharedTokenSourceContext returns the broadcaster's context or the fallback if unavailable.
@@ -1845,6 +1905,9 @@ func (b *Broadcaster) clearCreatedXBLClientReferences(created map[*xsapi.Client]
 			b.conf.SubAccounts[i].XBLClient = nil
 		}
 	}
+	b.galleryMu.Lock()
+	b.subMinecraftTokens = nil
+	b.galleryMu.Unlock()
 }
 
 // xblClientCreated reports whether a client was created by the broadcaster.

--- a/config.go
+++ b/config.go
@@ -176,12 +176,13 @@ type FriendSyncConfig struct {
 }
 
 type SubAccountConfig struct {
-	ID             string
-	Enabled        bool
-	XBLClient      *xsapi.Client
-	XBLTokenSource xsapi.TokenSource
-	XUID           string
-	PublishConfig  mpsd.PublishConfig
+	ID                   string
+	Enabled              bool
+	XBLClient            *xsapi.Client
+	XBLTokenSource       xsapi.TokenSource
+	MinecraftTokenSource service.TokenSource
+	XUID                 string
+	PublishConfig        mpsd.PublishConfig
 	// FriendSync overrides the primary account's friend sync configuration for
 	// this sub-account. If nil, the primary configuration is used.
 	FriendSync *FriendSyncConfig

--- a/gallery_test.go
+++ b/gallery_test.go
@@ -7,6 +7,7 @@ import (
 	"image/color"
 	"image/png"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,8 +15,88 @@ import (
 	"testing"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2"
 	"github.com/sandertv/gophertunnel/minecraft/service"
 )
+
+func TestBroadcasterUploadsGalleryForEnabledSubAccounts(t *testing.T) {
+	imagePath := testGalleryImageFile(t)
+	seen := map[string]string{}
+	client := &http.Client{Transport: galleryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/xuid/") {
+			xuid := req.URL.Path[strings.LastIndex(req.URL.Path, "/")+1:]
+			seen[xuid] = req.Header.Get("Authorization")
+			if xuid == "bad" {
+				return galleryHTTPResponse(http.StatusInternalServerError, ""), nil
+			}
+			return galleryHTTPResponse(http.StatusOK, `{"result":{"showcasedImages":[]}}`), nil
+		}
+		if req.Method == http.MethodPost && req.URL.Path == "/api/v1.0/gallery" {
+			return galleryHTTPResponse(http.StatusAccepted, `{"result":{"id":"new"}}`), nil
+		}
+		t.Fatalf("unexpected request %s %s", req.Method, req.URL)
+		return nil, nil
+	})}
+	b := &Broadcaster{
+		ctx: context.Background(),
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		conf: Config{
+			XUID: "primary",
+			Gallery: &GalleryConfig{
+				Enabled:     true,
+				ImagePath:   imagePath,
+				TokenSource: galleryTokenSource{authorization: "Bearer primary"},
+				Client:      client,
+			},
+			SubAccounts: []SubAccountConfig{
+				{
+					ID:                   "good",
+					Enabled:              true,
+					XBLClient:            &xsapi.Client{},
+					XUID:                 "good",
+					MinecraftTokenSource: galleryTokenSource{authorization: "Bearer good"},
+				},
+				{
+					ID:                   "bad",
+					Enabled:              true,
+					XBLClient:            &xsapi.Client{},
+					XUID:                 "bad",
+					MinecraftTokenSource: galleryTokenSource{authorization: "Bearer bad"},
+				},
+				{
+					ID:                   "after-failure",
+					Enabled:              true,
+					XBLClient:            &xsapi.Client{},
+					XUID:                 "after-failure",
+					MinecraftTokenSource: galleryTokenSource{authorization: "Bearer after-failure"},
+				},
+				{
+					ID:                   "disabled",
+					Enabled:              false,
+					XBLClient:            &xsapi.Client{},
+					XUID:                 "disabled",
+					MinecraftTokenSource: galleryTokenSource{authorization: "Bearer disabled"},
+				},
+			},
+		},
+	}
+
+	b.uploadGallery(context.Background())
+
+	for xuid, authorization := range map[string]string{
+		"primary":       "Bearer primary",
+		"good":          "Bearer good",
+		"bad":           "Bearer bad",
+		"after-failure": "Bearer after-failure",
+	} {
+		if got := seen[xuid]; got != authorization {
+			t.Fatalf("gallery authorization for %s = %q, want %q", xuid, got, authorization)
+		}
+	}
+	if _, ok := seen["disabled"]; ok {
+		t.Fatal("disabled sub-account gallery was uploaded")
+	}
+}
 
 func TestGalleryClientReusesReencodedEquivalentImage(t *testing.T) {
 	localImage := testPNG(t, png.BestCompression)
@@ -235,4 +316,12 @@ type galleryMinecraftTokenSource struct{}
 
 func (galleryMinecraftTokenSource) ServiceToken(context.Context) (*service.Token, error) {
 	return &service.Token{AuthorizationHeader: "Bearer minecraft", ValidUntil: time.Now().Add(time.Hour)}, nil
+}
+
+type galleryTokenSource struct {
+	authorization string
+}
+
+func (s galleryTokenSource) ServiceToken(context.Context) (*service.Token, error) {
+	return &service.Token{AuthorizationHeader: s.authorization, ValidUntil: time.Now().Add(time.Hour)}, nil
 }


### PR DESCRIPTION
## Summary

- upload the configured showcase image for every enabled subaccount
- derive and cache a Minecraft service token source per Xbox client
- isolate account failures and preserve primary-account behavior
- serialize gallery refreshes to avoid racing token-cache updates

## Why

Subaccounts publish the same world to their own friend graph, but only the primary account received the configured showcase image.

## Validation

- go test ./... -count=1
- go test -race ./... -count=1
- go vet ./...
- git diff --check