### PR TITLE
Publish independently joinable subaccount sessions

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -42,18 +42,18 @@ type Broadcaster struct {
 	conf Config
 	log  *slog.Logger
 
-	announcer           room.Announcer
-	listener            *minecraft.Listener
-	signaling           nethernet.Signaling
-	sessionRef          mpsd.SessionReference
-	subSessions         []*mpsd.Session
-	subSessionsByID     map[string]*mpsd.Session
-	announcerFactory    func(*Broadcaster) room.Announcer
-	subAccountPublisher func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error)
-	xblClient           *xsapi.Client
-	minecraftTokens     service.TokenSource
-	subMinecraftTokens  map[*xsapi.Client]service.TokenSource
-	createdXBLClients   []*xsapi.Client
+	announcer                  room.Announcer
+	listener                   *minecraft.Listener
+	signaling                  nethernet.Signaling
+	sessionRef                 mpsd.SessionReference
+	sessionConnection          *room.Connection
+	subAnnouncersByID          map[string]room.Announcer
+	announcerFactory           func(*Broadcaster) room.Announcer
+	subAccountAnnouncerFactory func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error)
+	xblClient                  *xsapi.Client
+	minecraftTokens            service.TokenSource
+	subMinecraftTokens         map[*xsapi.Client]service.TokenSource
+	createdXBLClients          []*xsapi.Client
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -69,7 +69,7 @@ type Broadcaster struct {
 	lastQuery *minecraft.ServerStatus
 
 	transferCloseTimeout time.Duration
-	// subAccountStartTimeout bounds each sub-account's session join so a hung
+	// subAccountStartTimeout bounds each sub-account's session publish so a hung
 	// directory or RTA call degrades to a skipped sub-account instead of
 	// blocking broadcaster startup. Zero uses the default.
 	subAccountStartTimeout time.Duration
@@ -185,7 +185,8 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 		return errors.Join(err, b.cleanupStartupFailure(true))
 	}
 	if connection != nil {
-		b.announcer = signalingConnectionAnnouncer{Announcer: b.announcer, connection: *connection}
+		b.sessionConnection = connection
+		b.announcer = signalingConnectionAnnouncer{Announcer: b.announcer, connection: *b.sessionConnection}
 		b.debug("using jsonrpc signaling", "nethernet_id", connection.NetherNetID, "pmsg_id", connection.PmsgID)
 	} else if len(status.SupportedConnections) == 0 {
 		// Without a signaling connection or caller-provided connections the
@@ -202,7 +203,7 @@ func (b *Broadcaster) Start(ctx context.Context) error {
 	}
 	b.info("created xbox live session")
 	b.debug("starting sub-account sessions", "count", len(b.conf.SubAccounts))
-	if err := b.startSubAccounts(b.ctx); err != nil {
+	if err := b.startSubAccounts(b.ctx, status); err != nil {
 		b.cancel()
 		err = errors.Join(err, b.cleanupStartupFailure(true))
 		return err
@@ -585,8 +586,8 @@ func (i *broadcasterInviter) Invite(ctx context.Context, xuid, titleID string) e
 	return err
 }
 
-// subAccountInviter sends friend invites through a sub-account's joined
-// session, resolved dynamically so invites work as soon as the join lands.
+// subAccountInviter sends friend invites through a sub-account's independently
+// published session, resolved dynamically so invites survive session rebuilds.
 type subAccountInviter struct {
 	b  *Broadcaster
 	id string
@@ -594,10 +595,17 @@ type subAccountInviter struct {
 
 func (i *subAccountInviter) Invite(ctx context.Context, xuid, titleID string) error {
 	i.b.mu.Lock()
-	session := i.b.subSessionsByID[i.id]
+	announcer := i.b.subAnnouncersByID[i.id]
 	i.b.mu.Unlock()
+	xbl, ok := xblAnnouncer(announcer)
+	if !ok {
+		return errors.New("invite: sub-account has not published a session")
+	}
+	xbl.Lock()
+	session := xbl.Session
+	xbl.Unlock()
 	if session == nil {
-		return errors.New("invite: sub-account has not joined the session")
+		return errors.New("invite: sub-account has not published a session")
 	}
 	_, err := session.Invite(ctx, xuid, titleID)
 	return err
@@ -854,10 +862,12 @@ func (b *Broadcaster) newAnnouncer(ctx context.Context) (room.Announcer, error) 
 	}, b.primaryXUID(), b.log), nil
 }
 
-// startSubAccounts joins the primary session with all enabled sub-accounts.
+// startSubAccounts publishes an independently owned session for every enabled
+// sub-account. All sessions advertise the same NetherNet signaling connection,
+// so each account is directly joinable while routing players to one listener.
 // A failing sub-account is logged and skipped so it cannot take down the
 // broadcaster, matching MCXboxBroadcast.
-func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
+func (b *Broadcaster) startSubAccounts(ctx context.Context, status room.Status) error {
 	for i := range b.conf.SubAccounts {
 		account := &b.conf.SubAccounts[i]
 		b.debug("checking sub-account",
@@ -873,7 +883,7 @@ func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
 			b.log.Warn("sub-account skipped because xbox live credentials are missing", "sub_account", account.ID)
 			continue
 		}
-		if err := b.startSubAccountBounded(ctx, account); err != nil {
+		if err := b.startSubAccountBounded(ctx, account, status); err != nil {
 			// A canceled context means the broadcaster is shutting down, not
 			// that this or the remaining sub-accounts genuinely failed.
 			if ctx.Err() != nil {
@@ -886,21 +896,21 @@ func (b *Broadcaster) startSubAccounts(ctx context.Context) error {
 	return nil
 }
 
-// startSubAccount prepares one sub-account and joins it to the primary session.
+// startSubAccount prepares one sub-account and publishes its own session.
 // startSubAccountBounded runs startSubAccount under the per-account timeout.
-// The context only scopes the join requests; the sub-account's RTA connection
-// and session outlive it.
-func (b *Broadcaster) startSubAccountBounded(ctx context.Context, account *SubAccountConfig) error {
+// The context only scopes the publish requests; the sub-account's RTA
+// connection and session outlive it.
+func (b *Broadcaster) startSubAccountBounded(ctx context.Context, account *SubAccountConfig, status room.Status) error {
 	timeout := b.subAccountStartTimeout
 	if timeout <= 0 {
 		timeout = 90 * time.Second
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	return b.startSubAccount(ctx, account)
+	return b.startSubAccount(ctx, account, status)
 }
 
-func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountConfig) error {
+func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountConfig, status room.Status) error {
 	if _, err := b.subAccountXBLClient(ctx, account); err != nil {
 		return fmt.Errorf("prepare xbox live client: %w", err)
 	}
@@ -908,39 +918,49 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 		account.XUID = accountXUID(*account)
 	}
 	if account.XUID == "" {
-		b.log.Warn("sub-account xuid unavailable", "sub_account", account.ID)
+		return errors.New("sub-account xuid unavailable")
 	}
 	if err := b.ensureSubAccountMutualFollow(ctx, *account); err != nil {
 		return fmt.Errorf("prepare mutual follow: %w", err)
 	}
-	pub := account.PublishConfig
-	b.debug("joining sub-account to session",
+	ref := mpsd.SessionReference{
+		ServiceConfigID: serviceConfigUUID,
+		TemplateName:    TemplateName,
+		Name:            strings.ToUpper(uuid.NewString()),
+	}
+	b.debug("publishing independent sub-account session",
 		"sub_account", account.ID,
 		"xuid", account.XUID,
-		"session_name", b.sessionRef.Name,
+		"session_name", ref.Name,
 	)
-	s, err := b.joinSubAccount(ctx, *account, pub)
+	announcer, err := b.newSubAccountAnnouncer(ctx, *account, ref)
 	if err != nil {
-		return fmt.Errorf("join session: %w", err)
+		return fmt.Errorf("create announcer: %w", err)
 	}
+	announcer = loggingAnnouncer{Announcer: announcer, log: b.log.With("sub_account", account.ID)}
+	if b.sessionConnection != nil {
+		announcer = signalingConnectionAnnouncer{Announcer: announcer, connection: *b.sessionConnection}
+	}
+	if err := announcer.Announce(ctx, subAccountStatus(status, account.XUID)); err != nil {
+		_ = announcer.Close()
+		return fmt.Errorf("announce session: %w", err)
+	}
+
 	// b.mu is held by Start for the whole startup sequence, so the session
 	// bookkeeping mutates directly; locking here would self-deadlock.
-	b.subSessions = append(b.subSessions, s)
-	if b.subSessionsByID == nil {
-		b.subSessionsByID = make(map[string]*mpsd.Session)
+	if b.subAnnouncersByID == nil {
+		b.subAnnouncersByID = make(map[string]room.Announcer)
 	}
-	b.subSessionsByID[account.ID] = s
-	b.debug("joined sub-account to session", "sub_account", account.ID, "xuid", account.XUID)
+	b.subAnnouncersByID[account.ID] = announcer
+	b.debug("published independent sub-account session", "sub_account", account.ID, "xuid", account.XUID)
 	return nil
 }
 
-// joinSubAccount joins a sub-account to the primary session through the
-// primary account's activity handle. Publishing the same session reference
-// again would fail with 412 Precondition Failed, so the sub-account looks up
-// the handle and joins it like MCXboxBroadcast's sub-sessions.
-func (b *Broadcaster) joinSubAccount(ctx context.Context, account SubAccountConfig, pub mpsd.PublishConfig) (*mpsd.Session, error) {
-	if b.subAccountPublisher != nil {
-		return b.subAccountPublisher(ctx, account, b.sessionRef, pub)
+// newSubAccountAnnouncer creates an MPSD announcer owned by account. Its
+// session reference is deliberately distinct from the primary session.
+func (b *Broadcaster) newSubAccountAnnouncer(ctx context.Context, account SubAccountConfig, ref mpsd.SessionReference) (room.Announcer, error) {
+	if b.subAccountAnnouncerFactory != nil {
+		return b.subAccountAnnouncerFactory(ctx, account, ref)
 	}
 	if account.XBLClient == nil {
 		return nil, errors.New("sub-account xbox live client is nil")
@@ -949,38 +969,11 @@ func (b *Broadcaster) joinSubAccount(ctx context.Context, account SubAccountConf
 	if client == nil {
 		return nil, errors.New("sub-account MPSD client is nil")
 	}
-	handleID, err := b.primaryActivityHandleID(ctx, client)
-	if err != nil {
-		return nil, err
-	}
-	b.debug("resolved primary activity handle", "sub_account", account.ID, "handle_id", handleID)
-	s, err := client.Join(ctx, handleID, mpsd.JoinConfig{})
-	if err != nil {
-		return nil, fmt.Errorf("join handle %s: %w", handleID, err)
-	}
-	// Join publishes the sub-account's own activity handle as part of session
-	// creation, which is what makes the session visible to the sub-account's
-	// friends; no extra handle write is needed here.
-	return s, nil
-}
-
-// primaryActivityHandleID finds the primary account's activity handle for the
-// published session.
-func (b *Broadcaster) primaryActivityHandleID(ctx context.Context, client *mpsd.Client) (uuid.UUID, error) {
-	primaryXUID := b.primaryXUID()
-	if primaryXUID == "" {
-		return uuid.Nil, errors.New("primary xuid unavailable for activity handle lookup")
-	}
-	handles, err := client.ActivitiesForUsers(ctx, b.sessionRef.ServiceConfigID, []string{primaryXUID})
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("query primary activity handles: %w", err)
-	}
-	for _, handle := range handles {
-		if handle.SessionReference.Name == b.sessionRef.Name {
-			return handle.ID, nil
-		}
-	}
-	return uuid.Nil, fmt.Errorf("no activity handle found for session %q", b.sessionRef.Name)
+	return newSessionNonceAnnouncer(&room.XBLAnnouncer{
+		Client:           client,
+		SessionReference: ref,
+		PublishConfig:    account.PublishConfig,
+	}, account.XUID, b.log.With("sub_account", account.ID)), nil
 }
 
 // ensureSubAccountMutualFollow makes the primary and sub-account follow each
@@ -1593,9 +1586,21 @@ func (b *Broadcaster) sessionUnhealthyReason() string {
 	if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
 		return fmt.Sprintf("session has %d/30 members", count)
 	}
-	for _, s := range b.subSessions {
-		if s.Context().Err() != nil {
+	for id, subAnnouncer := range b.subAnnouncersByID {
+		xbl, ok := xblAnnouncer(subAnnouncer)
+		if !ok {
+			continue
+		}
+		xbl.Lock()
+		session := xbl.Session
+		xbl.Unlock()
+		if session != nil && session.Context().Err() != nil {
 			return "sub-account session lost"
+		}
+		if session != nil {
+			if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
+				return fmt.Sprintf("sub-account %s session has %d/30 members", id, count)
+			}
 		}
 	}
 	return ""
@@ -1794,13 +1799,14 @@ func (b *Broadcaster) recreateSession() error {
 		return fmt.Errorf("re-create signaling connection: %w", err)
 	}
 	if connection != nil {
-		b.announcer = signalingConnectionAnnouncer{Announcer: b.announcer, connection: *connection}
+		b.sessionConnection = connection
+		b.announcer = signalingConnectionAnnouncer{Announcer: b.announcer, connection: *b.sessionConnection}
 	}
 	if err := b.announcer.Announce(b.ctx, status); err != nil {
 		closeSignaling()
 		return fmt.Errorf("re-announce session: %w", err)
 	}
-	if err := b.startSubAccounts(b.ctx); err != nil {
+	if err := b.startSubAccounts(b.ctx, status); err != nil {
 		_ = b.cleanupPublishedSessions(true)
 		closeSignaling()
 		return fmt.Errorf("re-create sub-accounts: %w", err)
@@ -1844,6 +1850,20 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 	if err := b.announcer.Announce(ctx, status); err != nil {
 		return err
 	}
+	var subErr error
+	for i := range b.conf.SubAccounts {
+		account := &b.conf.SubAccounts[i]
+		announcer := b.subAnnouncersByID[account.ID]
+		if announcer == nil {
+			continue
+		}
+		if err := announcer.Announce(ctx, subAccountStatus(status, accountXUID(*account))); err != nil {
+			subErr = errors.Join(subErr, fmt.Errorf("update sub-account %s: %w", account.ID, err))
+		}
+	}
+	if subErr != nil {
+		return subErr
+	}
 	// Matching MCXboxBroadcast, suppressSessionUpdateMessage only demotes the
 	// periodic success log to debug level.
 	if b.conf.SuppressSessionUpdateMessage {
@@ -1854,16 +1874,18 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 	return nil
 }
 
-// cleanupPublishedSessions closes sub-sessions and optionally the announcer.
+// cleanupPublishedSessions closes independent sub-account sessions and
+// optionally the primary announcer.
 func (b *Broadcaster) cleanupPublishedSessions(closeAnnouncer bool) error {
 	var err error
-	for _, s := range b.subSessions {
-		err = errors.Join(err, s.Close())
+	for _, announcer := range b.subAnnouncersByID {
+		err = errors.Join(err, announcer.Close())
 	}
-	b.subSessions = nil
+	b.subAnnouncersByID = nil
 	if closeAnnouncer && b.announcer != nil {
 		err = errors.Join(err, b.announcer.Close())
 	}
+	b.sessionConnection = nil
 	return err
 }
 

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -47,6 +47,7 @@ type Broadcaster struct {
 	signaling                  nethernet.Signaling
 	sessionRef                 mpsd.SessionReference
 	sessionConnection          *room.Connection
+	subAnnouncers              []publishedSubAccount
 	subAnnouncersByID          map[string]room.Announcer
 	announcerFactory           func(*Broadcaster) room.Announcer
 	subAccountAnnouncerFactory func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error)
@@ -79,6 +80,12 @@ type Broadcaster struct {
 	// galleryUploadTimeout bounds each account's gallery upload. Zero uses the
 	// default.
 	galleryUploadTimeout time.Duration
+}
+
+type publishedSubAccount struct {
+	id        string
+	xuid      string
+	announcer room.Announcer
 }
 
 type transferConn interface {
@@ -951,6 +958,11 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	if b.subAnnouncersByID == nil {
 		b.subAnnouncersByID = make(map[string]room.Announcer)
 	}
+	b.subAnnouncers = append(b.subAnnouncers, publishedSubAccount{
+		id:        account.ID,
+		xuid:      account.XUID,
+		announcer: announcer,
+	})
 	b.subAnnouncersByID[account.ID] = announcer
 	b.debug("published independent sub-account session", "sub_account", account.ID, "xuid", account.XUID)
 	return nil
@@ -1586,8 +1598,8 @@ func (b *Broadcaster) sessionUnhealthyReason() string {
 	if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
 		return fmt.Sprintf("session has %d/30 members", count)
 	}
-	for id, subAnnouncer := range b.subAnnouncersByID {
-		xbl, ok := xblAnnouncer(subAnnouncer)
+	for _, sub := range b.subAnnouncers {
+		xbl, ok := xblAnnouncer(sub.announcer)
 		if !ok {
 			continue
 		}
@@ -1599,7 +1611,7 @@ func (b *Broadcaster) sessionUnhealthyReason() string {
 		}
 		if session != nil {
 			if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
-				return fmt.Sprintf("sub-account %s session has %d/30 members", id, count)
+				return fmt.Sprintf("sub-account %s session has %d/30 members", sub.id, count)
 			}
 		}
 	}
@@ -1851,14 +1863,9 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 		return err
 	}
 	var subErr error
-	for i := range b.conf.SubAccounts {
-		account := &b.conf.SubAccounts[i]
-		announcer := b.subAnnouncersByID[account.ID]
-		if announcer == nil {
-			continue
-		}
-		if err := announcer.Announce(ctx, subAccountStatus(status, accountXUID(*account))); err != nil {
-			subErr = errors.Join(subErr, fmt.Errorf("update sub-account %s: %w", account.ID, err))
+	for _, sub := range b.subAnnouncers {
+		if err := sub.announcer.Announce(ctx, subAccountStatus(status, sub.xuid)); err != nil {
+			subErr = errors.Join(subErr, fmt.Errorf("update sub-account %s: %w", sub.id, err))
 		}
 	}
 	if subErr != nil {
@@ -1878,9 +1885,10 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 // optionally the primary announcer.
 func (b *Broadcaster) cleanupPublishedSessions(closeAnnouncer bool) error {
 	var err error
-	for _, announcer := range b.subAnnouncersByID {
-		err = errors.Join(err, announcer.Close())
+	for _, sub := range b.subAnnouncers {
+		err = errors.Join(err, sub.announcer.Close())
 	}
+	b.subAnnouncers = nil
 	b.subAnnouncersByID = nil
 	if closeAnnouncer && b.announcer != nil {
 		err = errors.Join(err, b.announcer.Close())

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -42,12 +42,12 @@ func TestBroadcasterStartSubAccountsMutuallyFollowsBeforePublish(t *testing.T) {
 			XUID:      "200",
 		}},
 	}}
-	b.subAccountPublisher = func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
 		calls = append(calls, "publish")
-		return &mpsd.Session{}, nil
+		return &fakeAnnouncer{}, nil
 	}
 
-	if err := b.startSubAccounts(context.Background()); err != nil {
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
@@ -87,12 +87,12 @@ func TestBroadcasterStartSubAccountsSkipsExistingMutualFollow(t *testing.T) {
 			XUID:      "200",
 		}},
 	}}
-	b.subAccountPublisher = func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
 		calls = append(calls, "publish")
-		return &mpsd.Session{}, nil
+		return &fakeAnnouncer{}, nil
 	}
 
-	if err := b.startSubAccounts(context.Background()); err != nil {
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
 		t.Fatal(err)
 	}
 	for _, call := range calls {
@@ -120,13 +120,13 @@ func TestBroadcasterStartSubAccountsStopsQuietlyOnContextCancel(t *testing.T) {
 			{ID: "second", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
 		},
 	}}
-	b.subAccountPublisher = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference, _ mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference) (room.Announcer, error) {
 		started = append(started, account.ID)
 		cancel()
 		return nil, ctx.Err()
 	}
 
-	err := b.startSubAccounts(ctx)
+	err := b.startSubAccounts(ctx, room.Status{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("startSubAccounts() error = %v, want context.Canceled", err)
 	}
@@ -167,15 +167,15 @@ func TestBroadcasterStartSubAccountsContinuesPastFailingAccount(t *testing.T) {
 			{ID: "good", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "100"},
 		},
 	}}
-	b.subAccountPublisher = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference, _ mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(_ context.Context, account SubAccountConfig, _ mpsd.SessionReference) (room.Announcer, error) {
 		if account.ID == "bad" {
 			return nil, errors.New("boom")
 		}
 		published = append(published, account.ID)
-		return &mpsd.Session{}, nil
+		return &fakeAnnouncer{}, nil
 	}
 
-	if err := b.startSubAccounts(context.Background()); err != nil {
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
 		t.Fatalf("startSubAccounts() error = %v, want nil (bad account skipped)", err)
 	}
 	if fmt.Sprint(published) != "[good]" {
@@ -198,12 +198,12 @@ func TestBroadcasterStartSubAccountsSkipsMutualFollowWithoutXUIDs(t *testing.T) 
 			XUID:      "200",
 		}},
 	}}
-	b.subAccountPublisher = func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
 		publishCalls++
-		return &mpsd.Session{}, nil
+		return &fakeAnnouncer{}, nil
 	}
 
-	if err := b.startSubAccounts(context.Background()); err != nil {
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
 		t.Fatal(err)
 	}
 	if httpCalls != 0 {
@@ -228,12 +228,12 @@ func TestBroadcasterStartSubAccountsSkipsEnabledAccountWithoutCredentials(t *tes
 			Enabled: true,
 		}},
 	}}
-	b.subAccountPublisher = func(context.Context, SubAccountConfig, mpsd.SessionReference, mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
 		publishCalls++
-		return &mpsd.Session{}, nil
+		return &fakeAnnouncer{}, nil
 	}
 
-	if err := b.startSubAccounts(context.Background()); err != nil {
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
 		t.Fatal(err)
 	}
 	if httpCalls != 0 {
@@ -887,7 +887,7 @@ func TestStartSubAccountsTimeoutDoesNotBlockStartup(t *testing.T) {
 	b.ctx, b.cancel = context.WithCancel(context.Background())
 	defer b.cancel()
 	b.subAccountStartTimeout = 50 * time.Millisecond
-	b.subAccountPublisher = func(ctx context.Context, _ SubAccountConfig, _ mpsd.SessionReference, _ mpsd.PublishConfig) (*mpsd.Session, error) {
+	b.subAccountAnnouncerFactory = func(ctx context.Context, _ SubAccountConfig, _ mpsd.SessionReference) (room.Announcer, error) {
 		<-ctx.Done() // a hung join must be bounded by the per-account timeout
 		return nil, ctx.Err()
 	}
@@ -897,7 +897,7 @@ func TestStartSubAccountsTimeoutDoesNotBlockStartup(t *testing.T) {
 		// re-locking inside the sub-account path deadlocks the test too.
 		b.mu.Lock()
 		defer b.mu.Unlock()
-		done <- b.startSubAccounts(b.ctx)
+		done <- b.startSubAccounts(b.ctx, room.Status{})
 	}()
 	select {
 	case err := <-done:

--- a/config.go
+++ b/config.go
@@ -52,8 +52,8 @@ type Config struct {
 	FriendSync *FriendSyncConfig
 	// FriendHistory records player activity for friend expiry.
 	FriendHistory HistoryStore
-	// SubAccounts contains additional accounts that join/publish the same MPSD
-	// session to extend friend-list visibility.
+	// SubAccounts contains additional accounts that publish independently owned
+	// MPSD sessions for the same NetherNet listener.
 	SubAccounts []SubAccountConfig
 
 	// Signaling is the NetherNet signaling connection used to accept clients.

--- a/status.go
+++ b/status.go
@@ -78,6 +78,15 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 	}), nil
 }
 
+// subAccountStatus makes a sub-account's activity independently joinable
+// while preserving the primary session's advertised NetherNet connection and
+// world metadata.
+func subAccountStatus(status room.Status, xuid string) room.Status {
+	status.OwnerID = xuid
+	status.LevelID = accountLevelID(xuid)
+	return status
+}
+
 // applyQueriedStatus overlays a queried server status onto the announced one.
 func applyQueriedStatus(st *Status, queried minecraft.ServerStatus) {
 	st.WorldName = queried.ServerName

--- a/subaccount_session_test.go
+++ b/subaccount_session_test.go
@@ -97,10 +97,14 @@ func TestBroadcasterUpdateRefreshesSubAccountSession(t *testing.T) {
 	primary := &fakeAnnouncer{}
 	sub := &fakeAnnouncer{}
 	b := &Broadcaster{
-		log:               testBroadcasterLogger(),
-		announcer:         primary,
-		subAnnouncersByID: map[string]room.Announcer{"sub1": sub},
-		started:           true,
+		log:       testBroadcasterLogger(),
+		announcer: primary,
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			xuid:      "sub",
+			announcer: sub,
+		}},
+		started: true,
 		conf: Config{
 			Server: ServerInfo{Host: "play.example.net", Port: 19132},
 			XUID:   "primary",
@@ -126,7 +130,11 @@ func TestBroadcasterUpdateRefreshesSubAccountSession(t *testing.T) {
 
 func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	sub := &fakeAnnouncer{}
-	b := &Broadcaster{subAnnouncersByID: map[string]room.Announcer{"sub1": sub}}
+	b := &Broadcaster{subAnnouncers: []publishedSubAccount{{
+		id:        "sub1",
+		xuid:      "sub",
+		announcer: sub,
+	}}}
 
 	if err := b.cleanupPublishedSessions(false); err != nil {
 		t.Fatal(err)
@@ -136,5 +144,37 @@ func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	}
 	if len(b.subAnnouncersByID) != 0 {
 		t.Fatalf("sub-account announcers retained after cleanup: %#v", b.subAnnouncersByID)
+	}
+}
+
+func TestBroadcasterCleanupRetainsDuplicateIDSubAccountSessions(t *testing.T) {
+	first := &fakeAnnouncer{}
+	second := &fakeAnnouncer{}
+	announcers := []room.Announcer{first, second}
+	b := &Broadcaster{
+		log: testBroadcasterLogger(),
+		conf: Config{
+			XBLClient: &xsapi.Client{},
+			XUID:      "same",
+			SubAccounts: []SubAccountConfig{
+				{ID: "duplicate", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "same"},
+				{ID: "duplicate", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "same"},
+			},
+		},
+		subAccountAnnouncerFactory: func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
+			next := announcers[0]
+			announcers = announcers[1:]
+			return next, nil
+		},
+	}
+
+	if err := b.startSubAccounts(context.Background(), room.Status{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.cleanupPublishedSessions(false); err != nil {
+		t.Fatal(err)
+	}
+	if !first.Closed() || !second.Closed() {
+		t.Fatalf("all independently published sessions must close: first=%v second=%v", first.Closed(), second.Closed())
 	}
 }

--- a/subaccount_session_test.go
+++ b/subaccount_session_test.go
@@ -1,0 +1,140 @@
+package broadcaster
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/df-mc/go-xsapi/v2"
+	"github.com/df-mc/go-xsapi/v2/mpsd"
+	"github.com/google/uuid"
+	"github.com/sandertv/gophertunnel/minecraft/p2p"
+	"github.com/sandertv/gophertunnel/minecraft/room"
+)
+
+func TestSubAccountStatusOwnsIndependentActivity(t *testing.T) {
+	connection := room.Connection{
+		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
+		NetherNetID:    "shared-nethernet",
+		PmsgID:         uuid.New(),
+	}
+	primary := room.Status{
+		OwnerID:              "primary",
+		LevelID:              accountLevelID("primary"),
+		HostName:             "Lunar",
+		WorldName:            "Lunar",
+		SupportedConnections: []room.Connection{connection},
+	}
+
+	got := subAccountStatus(primary, "sub")
+
+	if got.OwnerID != "sub" {
+		t.Fatalf("OwnerID = %q, want sub", got.OwnerID)
+	}
+	if got.LevelID != accountLevelID("sub") {
+		t.Fatalf("LevelID = %q, want account-specific level id", got.LevelID)
+	}
+	if fmt.Sprint(got.SupportedConnections) != fmt.Sprint(primary.SupportedConnections) {
+		t.Fatalf("SupportedConnections = %#v, want shared primary connection %#v", got.SupportedConnections, primary.SupportedConnections)
+	}
+	if primary.OwnerID != "primary" || primary.LevelID != accountLevelID("primary") {
+		t.Fatalf("subAccountStatus mutated primary status: %#v", primary)
+	}
+}
+
+func TestBroadcasterStartSubAccountPublishesIndependentSession(t *testing.T) {
+	connection := room.Connection{
+		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
+		NetherNetID:    "shared-nethernet",
+		PmsgID:         uuid.New(),
+	}
+	sub := &fakeAnnouncer{}
+	var ref mpsd.SessionReference
+	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "peoplehub.xboxlive.com" {
+			t.Fatalf("unexpected social request: %s %s", req.Method, req.URL)
+		}
+		return broadcasterResponse(http.StatusOK, `{"people":[{"xuid":"primary","isFollowingCaller":true,"isFollowedByCaller":true}]}`), nil
+	})}
+	b := &Broadcaster{
+		log:               testBroadcasterLogger(),
+		sessionRef:        mpsd.SessionReference{ServiceConfigID: serviceConfigUUID, TemplateName: TemplateName, Name: "PRIMARY"},
+		sessionConnection: &connection,
+		conf: Config{
+			XBLClient:  &xsapi.Client{},
+			XUID:       "primary",
+			HTTPClient: client,
+		},
+		subAccountAnnouncerFactory: func(_ context.Context, _ SubAccountConfig, got mpsd.SessionReference) (room.Announcer, error) {
+			ref = got
+			return sub, nil
+		},
+	}
+	account := &SubAccountConfig{ID: "sub1", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "sub"}
+	status := room.Status{OwnerID: "primary", LevelID: accountLevelID("primary")}
+
+	if err := b.startSubAccount(context.Background(), account, status); err != nil {
+		t.Fatal(err)
+	}
+
+	if ref.Name == "" || ref.Name == b.sessionRef.Name {
+		t.Fatalf("sub-account session name = %q, want non-empty name distinct from primary %q", ref.Name, b.sessionRef.Name)
+	}
+	got := sub.Status()
+	if got.OwnerID != "sub" || got.LevelID != accountLevelID("sub") {
+		t.Fatalf("sub-account published primary-owned status: %#v", got)
+	}
+	if len(got.SupportedConnections) != 1 || got.SupportedConnections[0] != connection {
+		t.Fatalf("sub-account connection = %#v, want shared connection %#v", got.SupportedConnections, connection)
+	}
+	if b.subAnnouncersByID["sub1"] == nil {
+		t.Fatal("sub-account announcer was not retained for updates and invites")
+	}
+}
+
+func TestBroadcasterUpdateRefreshesSubAccountSession(t *testing.T) {
+	primary := &fakeAnnouncer{}
+	sub := &fakeAnnouncer{}
+	b := &Broadcaster{
+		log:               testBroadcasterLogger(),
+		announcer:         primary,
+		subAnnouncersByID: map[string]room.Announcer{"sub1": sub},
+		started:           true,
+		conf: Config{
+			Server: ServerInfo{Host: "play.example.net", Port: 19132},
+			XUID:   "primary",
+			Status: Status{HostName: "Host", WorldName: "World"},
+			SubAccounts: []SubAccountConfig{{
+				ID:      "sub1",
+				Enabled: true,
+				XUID:    "sub",
+			}},
+		},
+	}
+
+	if err := b.Update(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := primary.Status(); got.OwnerID != "primary" {
+		t.Fatalf("primary OwnerID = %q, want primary", got.OwnerID)
+	}
+	if got := sub.Status(); got.OwnerID != "sub" || got.LevelID != accountLevelID("sub") {
+		t.Fatalf("sub-account update used primary ownership: %#v", got)
+	}
+}
+
+func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
+	sub := &fakeAnnouncer{}
+	b := &Broadcaster{subAnnouncersByID: map[string]room.Announcer{"sub1": sub}}
+
+	if err := b.cleanupPublishedSessions(false); err != nil {
+		t.Fatal(err)
+	}
+	if !sub.Closed() {
+		t.Fatal("sub-account announcer was not closed")
+	}
+	if len(b.subAnnouncersByID) != 0 {
+		t.Fatalf("sub-account announcers retained after cleanup: %#v", b.subAnnouncersByID)
+	}
+}


### PR DESCRIPTION
## Summary
- publish a distinct MPSD activity/session owned by each enabled subaccount
- advertise the main broadcaster's exact NetherNet signaling connection from every subaccount session
- update, health-check, invite through, rebuild, and close each independent session
- retain every published session even when account IDs collide

## Why
Subaccounts that only joined the primary account's MPSD session appeared online, but Minecraft did not expose a Join button on their profiles. Xbox activity is per player; publishing an account-owned activity lets Minecraft treat that subaccount as the joinable host while still routing to the same broadcaster listener.

## Verification
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `codex review --base origin/main` (clean after fixing the duplicate-ID cleanup finding)

Live viewer-token validation will be done after merge/deployment because the currently running broadcaster image predates this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-accounts now publish independent sessions while sharing the primary signaling connection.
  * Sub-account sessions can be invited, refreshed, monitored, and restarted independently.
  * Session status now reflects each sub-account’s ownership and activity.

* **Bug Fixes**
  * Improved resilience when a sub-account fails to start or loses connectivity.
  * Cleanup now reliably closes all independently published sub-account sessions.

* **Documentation**
  * Updated sub-account configuration guidance to describe independent session publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->