### PR TITLE
Harden independent subaccount session failures

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -875,6 +875,7 @@ func (b *Broadcaster) newAnnouncer(ctx context.Context) (room.Announcer, error) 
 // A failing sub-account is logged and skipped so it cannot take down the
 // broadcaster, matching MCXboxBroadcast.
 func (b *Broadcaster) startSubAccounts(ctx context.Context, status room.Status) error {
+	seenIDs := make(map[string]struct{}, len(b.conf.SubAccounts))
 	for i := range b.conf.SubAccounts {
 		account := &b.conf.SubAccounts[i]
 		b.debug("checking sub-account",
@@ -890,6 +891,12 @@ func (b *Broadcaster) startSubAccounts(ctx context.Context, status room.Status) 
 			b.log.Warn("sub-account skipped because xbox live credentials are missing", "sub_account", account.ID)
 			continue
 		}
+		if _, duplicate := seenIDs[account.ID]; duplicate {
+			b.log.Error("sub-account skipped because id is duplicated", "sub_account", account.ID)
+			b.notify(ctx, "Sub-account "+account.ID+" was skipped because its id is duplicated.")
+			continue
+		}
+		seenIDs[account.ID] = struct{}{}
 		if err := b.startSubAccountBounded(ctx, account, status); err != nil {
 			// A canceled context means the broadcaster is shutting down, not
 			// that this or the remaining sub-accounts genuinely failed.
@@ -1534,6 +1541,28 @@ const (
 	sessionUpdateFailureLimit = 3
 )
 
+// subAccountUpdateError reports that the primary session updated successfully
+// but one or more independently published sub-account sessions did not.
+type subAccountUpdateError struct {
+	err error
+}
+
+func (e *subAccountUpdateError) Error() string {
+	return e.err.Error()
+}
+
+func (e *subAccountUpdateError) Unwrap() error {
+	return e.err
+}
+
+func countsAsPrimaryUpdateFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var subErr *subAccountUpdateError
+	return !errors.As(err, &subErr)
+}
+
 // updateLoop periodically refreshes the Xbox session metadata, checking
 // session health before each update like Java's checkConnection().
 func (b *Broadcaster) updateLoop() {
@@ -1548,8 +1577,12 @@ func (b *Broadcaster) updateLoop() {
 				continue
 			}
 			ctx, cancel := context.WithTimeout(b.ctx, 15*time.Second)
-			if err := b.Update(ctx); err == nil {
+			err := b.Update(ctx)
+			if err == nil {
 				consecutiveFailures = 0
+			} else if !errors.Is(err, context.Canceled) && !countsAsPrimaryUpdateFailure(err) {
+				consecutiveFailures = 0
+				b.log.Error("update sub-account sessions", "err", err)
 			} else if !errors.Is(err, context.Canceled) {
 				consecutiveFailures++
 				b.log.Error("update session", "err", err)
@@ -1869,7 +1902,7 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 		}
 	}
 	if subErr != nil {
-		return subErr
+		return &subAccountUpdateError{err: subErr}
 	}
 	// Matching MCXboxBroadcast, suppressSessionUpdateMessage only demotes the
 	// periodic success log to debug level.

--- a/subaccount_session_test.go
+++ b/subaccount_session_test.go
@@ -2,6 +2,7 @@ package broadcaster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -128,6 +129,38 @@ func TestBroadcasterUpdateRefreshesSubAccountSession(t *testing.T) {
 	}
 }
 
+func TestBroadcasterSubAccountUpdateFailureDoesNotCountAsPrimaryFailure(t *testing.T) {
+	primary := &fakeAnnouncer{}
+	sub := &fakeAnnouncer{announceErr: fmt.Errorf("sub update failed")}
+	b := &Broadcaster{
+		log:       testBroadcasterLogger(),
+		announcer: primary,
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			xuid:      "sub",
+			announcer: sub,
+		}},
+		started: true,
+		conf: Config{
+			Server: ServerInfo{Host: "play.example.net", Port: 19132},
+			XUID:   "primary",
+			Status: Status{HostName: "Host", WorldName: "World"},
+		},
+	}
+
+	err := b.Update(context.Background())
+	var subErr *subAccountUpdateError
+	if !errors.As(err, &subErr) {
+		t.Fatalf("Update() error = %v, want subAccountUpdateError", err)
+	}
+	if countsAsPrimaryUpdateFailure(err) {
+		t.Fatalf("sub-account-only update error counted as primary failure: %v", err)
+	}
+	if !countsAsPrimaryUpdateFailure(fmt.Errorf("primary update failed")) {
+		t.Fatal("primary update error did not count as primary failure")
+	}
+}
+
 func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	sub := &fakeAnnouncer{}
 	b := &Broadcaster{subAnnouncers: []publishedSubAccount{{
@@ -147,10 +180,11 @@ func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	}
 }
 
-func TestBroadcasterCleanupRetainsDuplicateIDSubAccountSessions(t *testing.T) {
+func TestBroadcasterSkipsDuplicateIDsBeforePublishing(t *testing.T) {
 	first := &fakeAnnouncer{}
 	second := &fakeAnnouncer{}
 	announcers := []room.Announcer{first, second}
+	factoryCalls := 0
 	b := &Broadcaster{
 		log: testBroadcasterLogger(),
 		conf: Config{
@@ -162,6 +196,7 @@ func TestBroadcasterCleanupRetainsDuplicateIDSubAccountSessions(t *testing.T) {
 			},
 		},
 		subAccountAnnouncerFactory: func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
+			factoryCalls++
 			next := announcers[0]
 			announcers = announcers[1:]
 			return next, nil
@@ -174,7 +209,13 @@ func TestBroadcasterCleanupRetainsDuplicateIDSubAccountSessions(t *testing.T) {
 	if err := b.cleanupPublishedSessions(false); err != nil {
 		t.Fatal(err)
 	}
-	if !first.Closed() || !second.Closed() {
-		t.Fatalf("all independently published sessions must close: first=%v second=%v", first.Closed(), second.Closed())
+	if factoryCalls != 1 {
+		t.Fatalf("announcer factory calls = %d, want 1", factoryCalls)
+	}
+	if !first.Closed() {
+		t.Fatal("published session was not closed")
+	}
+	if second.Closed() {
+		t.Fatal("duplicate-ID session was published and retained")
 	}
 }


### PR DESCRIPTION
Follow-up to #24 addressing its final CodeRabbit findings:

- classify subaccount-only update failures so they are reported without incrementing the primary-session recreation counter
- skip duplicate subaccount IDs before publishing, keeping every invite lookup unambiguous
- add focused regression coverage for both behaviors

Verification:
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `codex review --base origin/main` on the complete change set (clean)