### PR TITLE
Give subaccounts independent signaling endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ The config exposes the same operator-facing areas as MCXboxBroadcast:
   database — operators migrating from MCXboxBroadcast start with a fresh
   expiry history)
 - Slack/Discord-compatible webhook notifications
-- primary and sub-account token cache paths
+- primary and sub-account token cache paths; every enabled sub-account
+  publishes its own Xbox activity and account-authenticated NetherNet
+  signaling endpoint so multiple broadcaster profiles remain joinable at once
 - optional HTTP proxy URL through `http.proxy`
 - NetherNet signaling mode through `session.signalingMode`; `jsonrpc` is the
   supported config value and matches MCXboxBroadcast's `ConnectionType=7`/

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ import (
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/google/uuid"
 	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/p2p"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
@@ -42,19 +44,23 @@ type Broadcaster struct {
 	conf Config
 	log  *slog.Logger
 
-	announcer                  room.Announcer
-	listener                   *minecraft.Listener
-	signaling                  nethernet.Signaling
-	sessionRef                 mpsd.SessionReference
-	sessionConnection          *room.Connection
-	subAnnouncers              []publishedSubAccount
-	subAnnouncersByID          map[string]room.Announcer
-	announcerFactory           func(*Broadcaster) room.Announcer
-	subAccountAnnouncerFactory func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error)
-	xblClient                  *xsapi.Client
-	minecraftTokens            service.TokenSource
-	subMinecraftTokens         map[*xsapi.Client]service.TokenSource
-	createdXBLClients          []*xsapi.Client
+	announcer                             room.Announcer
+	listener                              *minecraft.Listener
+	signaling                             nethernet.Signaling
+	sessionRef                            mpsd.SessionReference
+	sessionConnection                     *room.Connection
+	subAnnouncers                         []publishedSubAccount
+	subAnnouncersByID                     map[string]room.Announcer
+	announcerFactory                      func(*Broadcaster) room.Announcer
+	subAccountAnnouncerFactory            func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error)
+	subAccountSignalingFactory            func(context.Context, *SubAccountConfig) (nethernet.Signaling, error)
+	subAccountConnectionFactory           func(context.Context, *SubAccountConfig, nethernet.Signaling) (*room.Connection, error)
+	subAccountListenerFactory             func(nethernet.Signaling, room.Status) (net.Listener, error)
+	subAccountMinecraftTokenSourceFactory func(context.Context, *SubAccountConfig) (service.TokenSource, error)
+	xblClient                             *xsapi.Client
+	minecraftTokens                       service.TokenSource
+	subMinecraftTokens                    map[*xsapi.Client]service.TokenSource
+	createdXBLClients                     []*xsapi.Client
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -83,9 +89,12 @@ type Broadcaster struct {
 }
 
 type publishedSubAccount struct {
-	id        string
-	xuid      string
-	announcer room.Announcer
+	id         string
+	xuid       string
+	connection room.Connection
+	announcer  room.Announcer
+	signaling  nethernet.Signaling
+	listener   net.Listener
 }
 
 type transferConn interface {
@@ -704,6 +713,147 @@ func (b *Broadcaster) signalingFor(ctx context.Context) (nethernet.Signaling, er
 	}
 }
 
+// subAccountSignalingFor creates an account-authenticated signaling endpoint.
+// A distinct NetherNet/Pmsg identity is required because Minecraft collapses
+// otherwise independent activities that advertise the same signaling pair.
+func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAccountConfig) (nethernet.Signaling, error) {
+	if b.subAccountSignalingFactory != nil {
+		sig, err := b.subAccountSignalingFactory(ctx, account)
+		if err != nil {
+			return nil, err
+		}
+		return b.validateSubAccountSignaling(sig)
+	}
+
+	mode, err := b.signalingMode()
+	if err != nil {
+		return nil, err
+	}
+	tokens, err := b.subAccountMinecraftTokenSource(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("create minecraft token source: %w", err)
+	}
+	account.MinecraftTokenSource = tokens
+
+	if b.conf.SignalingFactory != nil {
+		subConf := b.conf
+		subConf.XBLClient = account.XBLClient
+		subConf.XBLTokenSource = account.XBLTokenSource
+		subConf.MinecraftTokenSource = tokens
+		subConf.XUID = account.XUID
+		subConf.Signaling = nil
+		subConf.SubAccounts = nil
+		sig, err := b.conf.SignalingFactory(ctx, subConf)
+		if err != nil {
+			return nil, err
+		}
+		return b.validateSubAccountSignaling(sig)
+	}
+
+	timeout := b.signalingDialTimeout()
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	result := dialDefaultSignaling(dialCtx, defaultSignalingConfig{
+		mode:            mode,
+		log:             b.log.With("sub_account", account.ID),
+		httpClient:      b.conf.HTTPClient,
+		xblClient:       account.XBLClient,
+		xblTokenSource:  account.XBLTokenSource,
+		minecraftTokens: tokens,
+	})
+	if result.err != nil {
+		closeDefaultSignalingResult(result)
+		return nil, result.err
+	}
+	sig, err := b.validateSubAccountSignaling(result.signaling)
+	if err != nil {
+		if result.createdClient != nil {
+			_ = result.createdClient.Close()
+		}
+		return nil, err
+	}
+	if result.createdClient != nil {
+		account.XBLClient = result.createdClient
+		b.createdXBLClients = append(b.createdXBLClients, result.createdClient)
+	}
+	if result.minecraft != nil {
+		account.MinecraftTokenSource = result.minecraft
+	}
+	return sig, nil
+}
+
+func (b *Broadcaster) validateSubAccountSignaling(sig nethernet.Signaling) (nethernet.Signaling, error) {
+	if sig == nil {
+		return nil, errors.New("signaling is nil")
+	}
+	if sameSignaling(sig, b.signaling) {
+		return nil, errors.New("sub-account signaling factory returned the primary signaling instance")
+	}
+	if sig.Context().Err() != nil {
+		_ = closeSignaling(sig)
+		return nil, errors.New("signaling has dead context")
+	}
+	if strings.TrimSpace(sig.NetworkID()) == "" {
+		_ = closeSignaling(sig)
+		return nil, errors.New("signaling network id is empty")
+	}
+	return sig, nil
+}
+
+func sameSignaling(a, b nethernet.Signaling) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	typ := reflect.TypeOf(a)
+	if typ != reflect.TypeOf(b) || !typ.Comparable() {
+		return false
+	}
+	return a == b
+}
+
+func (b *Broadcaster) subAccountConnection(ctx context.Context, account *SubAccountConfig, sig nethernet.Signaling) (*room.Connection, error) {
+	if b.subAccountConnectionFactory != nil {
+		return b.subAccountConnectionFactory(ctx, account, sig)
+	}
+	mode, err := b.signalingMode()
+	if err != nil {
+		return nil, err
+	}
+	if mode == SignalingModeWebSocket {
+		return &room.Connection{
+			ConnectionType: p2p.ConnectionTypeSignalingOverWebSocket,
+			NetherNetID:    p2p.NetherNetID(sig.NetworkID()),
+		}, nil
+	}
+	tokens, err := b.subAccountMinecraftTokenSource(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	return signalingConnectionWithTokenSource(ctx, sig, tokens)
+}
+
+func (b *Broadcaster) subAccountListener(sig nethernet.Signaling, status room.Status) (net.Listener, error) {
+	if b.subAccountListenerFactory != nil {
+		return b.subAccountListenerFactory(sig, status)
+	}
+	conf := b.minecraftListenConfig(status)
+	return conf.ListenNetwork(minecraft.NetherNet{
+		Signaling:    sig,
+		ListenConfig: b.netherNetListenConfig(),
+		Log:          b.log,
+	}, "")
+}
+
+func closeSignaling(sig nethernet.Signaling) error {
+	if sig == nil {
+		return nil
+	}
+	if closer, ok := sig.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
 // defaultSignalingConfig builds the signaling config from the broadcaster's current state.
 func (b *Broadcaster) defaultSignalingConfig(mode SignalingMode) defaultSignalingConfig {
 	client := b.conf.XBLClient
@@ -869,9 +1019,9 @@ func (b *Broadcaster) newAnnouncer(ctx context.Context) (room.Announcer, error) 
 	}, b.primaryXUID(), b.log), nil
 }
 
-// startSubAccounts publishes an independently owned session for every enabled
-// sub-account. All sessions advertise the same NetherNet signaling connection,
-// so each account is directly joinable while routing players to one listener.
+// startSubAccounts publishes an independently owned session and signaling
+// listener for every enabled sub-account. Every endpoint routes players to the
+// same configured target server.
 // A failing sub-account is logged and skipped so it cannot take down the
 // broadcaster, matching MCXboxBroadcast.
 func (b *Broadcaster) startSubAccounts(ctx context.Context, status room.Status) error {
@@ -937,6 +1087,32 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	if err := b.ensureSubAccountMutualFollow(ctx, *account); err != nil {
 		return fmt.Errorf("prepare mutual follow: %w", err)
 	}
+
+	var (
+		subSignaling  nethernet.Signaling
+		subConnection = b.sessionConnection
+	)
+	// Unit-level callers may exercise session publication without starting a
+	// complete broadcaster. A running broadcaster always has primary signaling
+	// and therefore creates an independent endpoint here.
+	independentEndpoint := b.signaling != nil || b.subAccountSignalingFactory != nil
+	if independentEndpoint {
+		var err error
+		subSignaling, err = b.subAccountSignalingFor(ctx, account)
+		if err != nil {
+			return fmt.Errorf("create signaling: %w", err)
+		}
+		subConnection, err = b.subAccountConnection(ctx, account, subSignaling)
+		if err != nil {
+			_ = closeSignaling(subSignaling)
+			return fmt.Errorf("create signaling connection: %w", err)
+		}
+	}
+	if independentEndpoint && subConnection == nil {
+		_ = closeSignaling(subSignaling)
+		return errors.New("sub-account session would publish no supported connection")
+	}
+
 	ref := mpsd.SessionReference{
 		ServiceConfigID: serviceConfigUUID,
 		TemplateName:    TemplateName,
@@ -949,15 +1125,35 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	)
 	announcer, err := b.newSubAccountAnnouncer(ctx, *account, ref)
 	if err != nil {
+		_ = closeSignaling(subSignaling)
 		return fmt.Errorf("create announcer: %w", err)
 	}
 	announcer = loggingAnnouncer{Announcer: announcer, log: b.log.With("sub_account", account.ID)}
-	if b.sessionConnection != nil {
-		announcer = signalingConnectionAnnouncer{Announcer: announcer, connection: *b.sessionConnection}
+	subStatus := subAccountStatus(status, account.XUID)
+	if subConnection != nil {
+		announcer = signalingConnectionAnnouncer{Announcer: announcer, connection: *subConnection}
+		subStatus = subAccountStatusWithConnection(status, account.XUID, *subConnection)
 	}
-	if err := announcer.Announce(ctx, subAccountStatus(status, account.XUID)); err != nil {
+	if err := announcer.Announce(ctx, subStatus); err != nil {
 		_ = announcer.Close()
+		_ = closeSignaling(subSignaling)
 		return fmt.Errorf("announce session: %w", err)
+	}
+
+	var subListener net.Listener
+	if subSignaling != nil {
+		listener, err := b.subAccountListener(subSignaling, subStatus)
+		if err != nil {
+			_ = announcer.Close()
+			_ = closeSignaling(subSignaling)
+			return fmt.Errorf("listen nethernet: %w", err)
+		}
+		if listener == nil {
+			_ = announcer.Close()
+			_ = closeSignaling(subSignaling)
+			return errors.New("listen nethernet: listener is nil")
+		}
+		subListener = listener
 	}
 
 	// b.mu is held by Start for the whole startup sequence, so the session
@@ -965,13 +1161,30 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	if b.subAnnouncersByID == nil {
 		b.subAnnouncersByID = make(map[string]room.Announcer)
 	}
-	b.subAnnouncers = append(b.subAnnouncers, publishedSubAccount{
+	published := publishedSubAccount{
 		id:        account.ID,
 		xuid:      account.XUID,
 		announcer: announcer,
-	})
+		signaling: subSignaling,
+		listener:  subListener,
+	}
+	if subConnection != nil {
+		published.connection = *subConnection
+	}
+	b.subAnnouncers = append(b.subAnnouncers, published)
 	b.subAnnouncersByID[account.ID] = announcer
-	b.debug("published independent sub-account session", "sub_account", account.ID, "xuid", account.XUID)
+	if subListener != nil {
+		b.acceptWg.Add(1)
+		go func() {
+			defer b.acceptWg.Done()
+			b.acceptListener(subListener)
+		}()
+	}
+	b.debug("published independent sub-account session",
+		"sub_account", account.ID,
+		"xuid", account.XUID,
+		"network_id", signalingNetworkID(subSignaling),
+	)
 	return nil
 }
 
@@ -1143,6 +1356,9 @@ func (b *Broadcaster) uploadGalleryAccount(ctx context.Context, cfg *GalleryConf
 }
 
 func (b *Broadcaster) subAccountMinecraftTokenSource(ctx context.Context, account *SubAccountConfig) (service.TokenSource, error) {
+	if b.subAccountMinecraftTokenSourceFactory != nil {
+		return b.subAccountMinecraftTokenSourceFactory(ctx, account)
+	}
 	if account.MinecraftTokenSource != nil {
 		return account.MinecraftTokenSource, nil
 	}
@@ -1151,6 +1367,7 @@ func (b *Broadcaster) subAccountMinecraftTokenSource(ctx context.Context, accoun
 		return nil, err
 	}
 	if tokens := b.subMinecraftTokens[client]; tokens != nil {
+		account.MinecraftTokenSource = tokens
 		return tokens, nil
 	}
 	tokens, err := newMinecraftTokenSource(ctx, client, b.conf.HTTPClient, b.log.With("sub_account", account.ID))
@@ -1161,6 +1378,7 @@ func (b *Broadcaster) subAccountMinecraftTokenSource(ctx context.Context, accoun
 		b.subMinecraftTokens = make(map[*xsapi.Client]service.TokenSource)
 	}
 	b.subMinecraftTokens[client] = tokens
+	account.MinecraftTokenSource = tokens
 	return tokens, nil
 }
 
@@ -1353,7 +1571,7 @@ func (b *Broadcaster) notifySessionUpdateFailure(ctx context.Context, err error)
 }
 
 // acceptListener accepts connections from the given listener and transfers each to the target server.
-func (b *Broadcaster) acceptListener(l *minecraft.Listener) {
+func (b *Broadcaster) acceptListener(l net.Listener) {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -1602,6 +1820,19 @@ func (b *Broadcaster) updateLoop() {
 // checkSessionHealth recreates the session when it is dead or nearly full and
 // reports whether a recreation was attempted.
 func (b *Broadcaster) checkSessionHealth() bool {
+	if id, sig := b.lostSubAccountSignaling(); id != "" && !b.canRecreateSignaling() {
+		reason := "sub-account " + id + " signaling lost"
+		b.warn("re-creating sub-account signaling", "sub_account", id, "reason", reason)
+		if err := b.reconnectSubAccount(id, sig); err != nil {
+			if b.ctx.Err() == nil {
+				b.log.Error("re-create sub-account failed", "sub_account", id, "reason", reason, "err", err)
+				b.notify(b.ctx, "Sub-account "+id+" recreation failed: "+err.Error())
+			}
+			return true
+		}
+		b.info("sub-account signaling re-created", "sub_account", id)
+		return true
+	}
 	reason := b.sessionUnhealthyReason()
 	if reason == "" {
 		return false
@@ -1610,11 +1841,29 @@ func (b *Broadcaster) checkSessionHealth() bool {
 	return true
 }
 
+// lostSubAccountSignaling returns the first independently published endpoint
+// whose signaling context has stopped.
+func (b *Broadcaster) lostSubAccountSignaling() (string, nethernet.Signaling) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, sub := range b.subAnnouncers {
+		if sub.signaling != nil && sub.signaling.Context().Err() != nil {
+			return sub.id, sub.signaling
+		}
+	}
+	return "", nil
+}
+
 // sessionUnhealthyReason reports why the published session needs recreation,
 // or an empty string when it is healthy.
 func (b *Broadcaster) sessionUnhealthyReason() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	for _, sub := range b.subAnnouncers {
+		if sub.signaling != nil && sub.signaling.Context().Err() != nil {
+			return "sub-account " + sub.id + " signaling lost"
+		}
+	}
 	announcer, ok := xblAnnouncer(b.announcer)
 	if !ok {
 		return ""
@@ -1747,6 +1996,82 @@ func (b *Broadcaster) reconnectSignaling(sig nethernet.Signaling) error {
 		b.log.Error("re-create session failed, retrying", "err", err, "retry_in", next)
 		b.notify(b.ctx, "Signaling reconnection failed, retrying in "+next.String()+": "+err.Error())
 	})
+}
+
+// reconnectSubAccount replaces one lost independently authenticated endpoint
+// without touching a statically configured primary signaling connection.
+func (b *Broadcaster) reconnectSubAccount(id string, lost nethernet.Signaling) error {
+	return retryWithBackoff(b.ctx, reconnectBackoffBase, reconnectBackoffMax, func() error {
+		return b.recreateSubAccount(id, lost)
+	}, func(err error, next time.Duration) {
+		b.log.Error("re-create sub-account failed, retrying", "sub_account", id, "err", err, "retry_in", next)
+		b.notify(b.ctx, "Sub-account "+id+" reconnection failed, retrying in "+next.String()+": "+err.Error())
+	})
+}
+
+// recreateSubAccount tears down a lost sub-account endpoint and republishes it.
+// The primary MPSD session, listener, and static signaling instance remain live.
+func (b *Broadcaster) recreateSubAccount(id string, lost nethernet.Signaling) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.ctx.Err() != nil || !b.started {
+		return errors.New("broadcaster is shut down")
+	}
+
+	account := b.subAccountConfigByID(id)
+	if account == nil || !account.Enabled {
+		return fmt.Errorf("sub-account %s is no longer enabled", id)
+	}
+
+	if index := b.publishedSubAccountIndex(id); index >= 0 {
+		current := b.subAnnouncers[index]
+		if !sameSignaling(current.signaling, lost) && current.signaling != nil && current.signaling.Context().Err() == nil {
+			return nil
+		}
+		_ = b.closePublishedSubAccount(current)
+		b.subAnnouncers = append(b.subAnnouncers[:index], b.subAnnouncers[index+1:]...)
+		delete(b.subAnnouncersByID, id)
+	}
+
+	status, err := b.status(b.ctx)
+	if err != nil {
+		return fmt.Errorf("resolve session status: %w", err)
+	}
+	if err := b.startSubAccountBounded(b.ctx, account, status); err != nil {
+		return fmt.Errorf("restart sub-account: %w", err)
+	}
+	return nil
+}
+
+func (b *Broadcaster) subAccountConfigByID(id string) *SubAccountConfig {
+	for i := range b.conf.SubAccounts {
+		if b.conf.SubAccounts[i].ID == id {
+			return &b.conf.SubAccounts[i]
+		}
+	}
+	return nil
+}
+
+func (b *Broadcaster) publishedSubAccountIndex(id string) int {
+	for i := range b.subAnnouncers {
+		if b.subAnnouncers[i].id == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func (b *Broadcaster) closePublishedSubAccount(sub publishedSubAccount) error {
+	var err error
+	if sub.listener != nil {
+		err = errors.Join(err, sub.listener.Close())
+	}
+	if sub.announcer != nil {
+		err = errors.Join(err, sub.announcer.Close())
+	}
+	err = errors.Join(err, closeSignaling(sub.signaling))
+	return err
 }
 
 // retryWithBackoff calls attempt until it returns nil or ctx is done, waiting
@@ -1897,7 +2222,11 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 	}
 	var subErr error
 	for _, sub := range b.subAnnouncers {
-		if err := sub.announcer.Announce(ctx, subAccountStatus(status, sub.xuid)); err != nil {
+		subStatus := subAccountStatus(status, sub.xuid)
+		if sub.connection != (room.Connection{}) {
+			subStatus = subAccountStatusWithConnection(status, sub.xuid, sub.connection)
+		}
+		if err := sub.announcer.Announce(ctx, subStatus); err != nil {
 			subErr = errors.Join(subErr, fmt.Errorf("update sub-account %s: %w", sub.id, err))
 		}
 	}
@@ -1919,7 +2248,7 @@ func (b *Broadcaster) Update(ctx context.Context) error {
 func (b *Broadcaster) cleanupPublishedSessions(closeAnnouncer bool) error {
 	var err error
 	for _, sub := range b.subAnnouncers {
-		err = errors.Join(err, sub.announcer.Close())
+		err = errors.Join(err, b.closePublishedSubAccount(sub))
 	}
 	b.subAnnouncers = nil
 	b.subAnnouncersByID = nil

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -66,10 +66,16 @@ type Broadcaster struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	mu        sync.Mutex
-	galleryMu sync.Mutex
-	started   bool
-	acceptWg  sync.WaitGroup
+	mu                   sync.Mutex
+	galleryMu            sync.Mutex
+	statusMu             sync.Mutex
+	subAccountMu         sync.Mutex
+	started              bool
+	closing              bool
+	closeState           *broadcasterCloseState
+	acceptWg             sync.WaitGroup
+	reconnectWg          sync.WaitGroup
+	subAccountReconnects map[string]nethernet.Signaling
 
 	// lastQuery is the most recent successful target-server query, kept so
 	// query failures fall back to real data instead of failing the update.
@@ -95,6 +101,11 @@ type publishedSubAccount struct {
 	announcer  room.Announcer
 	signaling  nethernet.Signaling
 	listener   net.Listener
+}
+
+type broadcasterCloseState struct {
+	done chan struct{}
+	err  error
 }
 
 type transferConn interface {
@@ -153,6 +164,9 @@ func New(conf Config) (*Broadcaster, error) {
 func (b *Broadcaster) Start(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.closing {
+		return errors.New("broadcaster is closing")
+	}
 	if b.started {
 		return errors.New("broadcaster already started")
 	}
@@ -582,7 +596,7 @@ type broadcasterInviter struct {
 // Invite snapshots the active MPSD session under the mutex and sends a game invite.
 func (i *broadcasterInviter) Invite(ctx context.Context, xuid, titleID string) error {
 	i.b.mu.Lock()
-	if !i.b.started {
+	if !i.b.started || i.b.closing {
 		i.b.mu.Unlock()
 		return errors.New("invite: broadcaster not started")
 	}
@@ -716,13 +730,13 @@ func (b *Broadcaster) signalingFor(ctx context.Context) (nethernet.Signaling, er
 // subAccountSignalingFor creates an account-authenticated signaling endpoint.
 // A distinct NetherNet/Pmsg identity is required because Minecraft collapses
 // otherwise independent activities that advertise the same signaling pair.
-func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAccountConfig) (nethernet.Signaling, error) {
+func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAccountConfig, primary nethernet.Signaling) (nethernet.Signaling, error) {
 	if b.subAccountSignalingFactory != nil {
 		sig, err := b.subAccountSignalingFactory(ctx, account)
 		if err != nil {
 			return nil, err
 		}
-		return b.validateSubAccountSignaling(sig)
+		return validateSubAccountSignaling(sig, primary)
 	}
 
 	mode, err := b.signalingMode()
@@ -747,7 +761,7 @@ func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAc
 		if err != nil {
 			return nil, err
 		}
-		return b.validateSubAccountSignaling(sig)
+		return validateSubAccountSignaling(sig, primary)
 	}
 
 	timeout := b.signalingDialTimeout()
@@ -765,7 +779,7 @@ func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAc
 		closeDefaultSignalingResult(result)
 		return nil, result.err
 	}
-	sig, err := b.validateSubAccountSignaling(result.signaling)
+	sig, err := validateSubAccountSignaling(result.signaling, primary)
 	if err != nil {
 		if result.createdClient != nil {
 			_ = result.createdClient.Close()
@@ -782,11 +796,11 @@ func (b *Broadcaster) subAccountSignalingFor(ctx context.Context, account *SubAc
 	return sig, nil
 }
 
-func (b *Broadcaster) validateSubAccountSignaling(sig nethernet.Signaling) (nethernet.Signaling, error) {
+func validateSubAccountSignaling(sig, primary nethernet.Signaling) (nethernet.Signaling, error) {
 	if sig == nil {
 		return nil, errors.New("signaling is nil")
 	}
-	if sameSignaling(sig, b.signaling) {
+	if sameSignaling(sig, primary) {
 		return nil, errors.New("sub-account signaling factory returned the primary signaling instance")
 	}
 	if sig.Context().Err() != nil {
@@ -1075,42 +1089,58 @@ func (b *Broadcaster) startSubAccountBounded(ctx context.Context, account *SubAc
 }
 
 func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountConfig, status room.Status) error {
+	primary := b.signaling
+	independentEndpoint := primary != nil || b.subAccountSignalingFactory != nil
+	published, err := b.prepareSubAccount(ctx, account, status, independentEndpoint, primary)
+	if err != nil {
+		return err
+	}
+	b.retainPublishedSubAccount(published)
+	return nil
+}
+
+// prepareSubAccount performs account and network work without mutating the
+// published-session collection. Callers install the returned resources under
+// b.mu with retainPublishedSubAccount.
+func (b *Broadcaster) prepareSubAccount(ctx context.Context, account *SubAccountConfig, status room.Status, independentEndpoint bool, primary nethernet.Signaling) (publishedSubAccount, error) {
+	b.subAccountMu.Lock()
+	defer b.subAccountMu.Unlock()
+
 	if _, err := b.subAccountXBLClient(ctx, account); err != nil {
-		return fmt.Errorf("prepare xbox live client: %w", err)
+		return publishedSubAccount{}, fmt.Errorf("prepare xbox live client: %w", err)
 	}
 	if account.XUID == "" {
 		account.XUID = accountXUID(*account)
 	}
 	if account.XUID == "" {
-		return errors.New("sub-account xuid unavailable")
+		return publishedSubAccount{}, errors.New("sub-account xuid unavailable")
 	}
 	if err := b.ensureSubAccountMutualFollow(ctx, *account); err != nil {
-		return fmt.Errorf("prepare mutual follow: %w", err)
+		return publishedSubAccount{}, fmt.Errorf("prepare mutual follow: %w", err)
 	}
 
-	var (
-		subSignaling  nethernet.Signaling
-		subConnection = b.sessionConnection
-	)
+	var subSignaling nethernet.Signaling
+	var subConnection *room.Connection
 	// Unit-level callers may exercise session publication without starting a
 	// complete broadcaster. A running broadcaster always has primary signaling
 	// and therefore creates an independent endpoint here.
-	independentEndpoint := b.signaling != nil || b.subAccountSignalingFactory != nil
 	if independentEndpoint {
 		var err error
-		subSignaling, err = b.subAccountSignalingFor(ctx, account)
+		subSignaling, err = b.subAccountSignalingFor(ctx, account, primary)
 		if err != nil {
-			return fmt.Errorf("create signaling: %w", err)
+			return publishedSubAccount{}, fmt.Errorf("create signaling: %w", err)
 		}
 		subConnection, err = b.subAccountConnection(ctx, account, subSignaling)
 		if err != nil {
 			_ = closeSignaling(subSignaling)
-			return fmt.Errorf("create signaling connection: %w", err)
+			return publishedSubAccount{}, fmt.Errorf("create signaling connection: %w", err)
 		}
+	} else {
+		subConnection = b.sessionConnection
 	}
 	if independentEndpoint && subConnection == nil {
 		_ = closeSignaling(subSignaling)
-		return errors.New("sub-account session would publish no supported connection")
+		return publishedSubAccount{}, errors.New("sub-account session would publish no supported connection")
 	}
 
 	ref := mpsd.SessionReference{
@@ -1126,7 +1156,7 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	announcer, err := b.newSubAccountAnnouncer(ctx, *account, ref)
 	if err != nil {
 		_ = closeSignaling(subSignaling)
-		return fmt.Errorf("create announcer: %w", err)
+		return publishedSubAccount{}, fmt.Errorf("create announcer: %w", err)
 	}
 	announcer = loggingAnnouncer{Announcer: announcer, log: b.log.With("sub_account", account.ID)}
 	subStatus := subAccountStatus(status, account.XUID)
@@ -1137,7 +1167,7 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	if err := announcer.Announce(ctx, subStatus); err != nil {
 		_ = announcer.Close()
 		_ = closeSignaling(subSignaling)
-		return fmt.Errorf("announce session: %w", err)
+		return publishedSubAccount{}, fmt.Errorf("announce session: %w", err)
 	}
 
 	var subListener net.Listener
@@ -1146,21 +1176,16 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 		if err != nil {
 			_ = announcer.Close()
 			_ = closeSignaling(subSignaling)
-			return fmt.Errorf("listen nethernet: %w", err)
+			return publishedSubAccount{}, fmt.Errorf("listen nethernet: %w", err)
 		}
 		if listener == nil {
 			_ = announcer.Close()
 			_ = closeSignaling(subSignaling)
-			return errors.New("listen nethernet: listener is nil")
+			return publishedSubAccount{}, errors.New("listen nethernet: listener is nil")
 		}
 		subListener = listener
 	}
 
-	// b.mu is held by Start for the whole startup sequence, so the session
-	// bookkeeping mutates directly; locking here would self-deadlock.
-	if b.subAnnouncersByID == nil {
-		b.subAnnouncersByID = make(map[string]room.Announcer)
-	}
 	published := publishedSubAccount{
 		id:        account.ID,
 		xuid:      account.XUID,
@@ -1171,21 +1196,28 @@ func (b *Broadcaster) startSubAccount(ctx context.Context, account *SubAccountCo
 	if subConnection != nil {
 		published.connection = *subConnection
 	}
+	return published, nil
+}
+
+// retainPublishedSubAccount installs a prepared endpoint. b.mu must be held.
+func (b *Broadcaster) retainPublishedSubAccount(published publishedSubAccount) {
+	if b.subAnnouncersByID == nil {
+		b.subAnnouncersByID = make(map[string]room.Announcer)
+	}
 	b.subAnnouncers = append(b.subAnnouncers, published)
-	b.subAnnouncersByID[account.ID] = announcer
-	if subListener != nil {
+	b.subAnnouncersByID[published.id] = published.announcer
+	if published.listener != nil {
 		b.acceptWg.Add(1)
 		go func() {
 			defer b.acceptWg.Done()
-			b.acceptListener(subListener)
+			b.acceptListener(published.listener)
 		}()
 	}
 	b.debug("published independent sub-account session",
-		"sub_account", account.ID,
-		"xuid", account.XUID,
-		"network_id", signalingNetworkID(subSignaling),
+		"sub_account", published.id,
+		"xuid", published.xuid,
+		"network_id", signalingNetworkID(published.signaling),
 	)
-	return nil
 }
 
 // newSubAccountAnnouncer creates an MPSD announcer owned by account. Its
@@ -1820,17 +1852,8 @@ func (b *Broadcaster) updateLoop() {
 // checkSessionHealth recreates the session when it is dead or nearly full and
 // reports whether a recreation was attempted.
 func (b *Broadcaster) checkSessionHealth() bool {
-	if id, sig := b.lostSubAccountSignaling(); id != "" && !b.canRecreateSignaling() {
-		reason := "sub-account " + id + " signaling lost"
-		b.warn("re-creating sub-account signaling", "sub_account", id, "reason", reason)
-		if err := b.reconnectSubAccount(id, sig); err != nil {
-			if b.ctx.Err() == nil {
-				b.log.Error("re-create sub-account failed", "sub_account", id, "reason", reason, "err", err)
-				b.notify(b.ctx, "Sub-account "+id+" recreation failed: "+err.Error())
-			}
-			return true
-		}
-		b.info("sub-account signaling re-created", "sub_account", id)
+	if id, sig := b.lostSubAccountSignaling(); id != "" {
+		b.startSubAccountReconnect(id, sig)
 		return true
 	}
 	reason := b.sessionUnhealthyReason()
@@ -1859,11 +1882,6 @@ func (b *Broadcaster) lostSubAccountSignaling() (string, nethernet.Signaling) {
 func (b *Broadcaster) sessionUnhealthyReason() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	for _, sub := range b.subAnnouncers {
-		if sub.signaling != nil && sub.signaling.Context().Err() != nil {
-			return "sub-account " + sub.id + " signaling lost"
-		}
-	}
 	announcer, ok := xblAnnouncer(b.announcer)
 	if !ok {
 		return ""
@@ -2009,38 +2027,118 @@ func (b *Broadcaster) reconnectSubAccount(id string, lost nethernet.Signaling) e
 	})
 }
 
+// startSubAccountReconnect schedules at most one retry loop per sub-account.
+// Recovery runs outside the health loop so a slow authentication service does
+// not block primary session updates.
+func (b *Broadcaster) startSubAccountReconnect(id string, lost nethernet.Signaling) bool {
+	b.mu.Lock()
+	if b.ctx == nil || b.ctx.Err() != nil || !b.started {
+		b.mu.Unlock()
+		return false
+	}
+	if b.subAccountReconnects == nil {
+		b.subAccountReconnects = make(map[string]nethernet.Signaling)
+	}
+	if _, reconnecting := b.subAccountReconnects[id]; reconnecting {
+		b.mu.Unlock()
+		return false
+	}
+	b.subAccountReconnects[id] = lost
+	b.reconnectWg.Add(1)
+	b.mu.Unlock()
+
+	b.warn("re-creating sub-account signaling", "sub_account", id)
+	go func() {
+		defer b.reconnectWg.Done()
+		err := b.reconnectSubAccount(id, lost)
+		b.mu.Lock()
+		delete(b.subAccountReconnects, id)
+		b.mu.Unlock()
+		if err == nil {
+			b.info("sub-account signaling re-created", "sub_account", id)
+		} else if b.ctx.Err() == nil {
+			b.log.Error("re-create sub-account failed", "sub_account", id, "err", err)
+			b.notify(b.ctx, "Sub-account "+id+" recreation failed: "+err.Error())
+		}
+	}()
+	return true
+}
+
 // recreateSubAccount tears down a lost sub-account endpoint and republishes it.
-// The primary MPSD session, listener, and static signaling instance remain live.
+// The primary MPSD session, listener, and signaling instance remain live.
 func (b *Broadcaster) recreateSubAccount(id string, lost nethernet.Signaling) error {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	if b.ctx.Err() != nil || !b.started {
+		b.mu.Unlock()
 		return errors.New("broadcaster is shut down")
 	}
 
 	account := b.subAccountConfigByID(id)
 	if account == nil || !account.Enabled {
+		b.mu.Unlock()
 		return fmt.Errorf("sub-account %s is no longer enabled", id)
 	}
 
+	var previous publishedSubAccount
+	hadPrevious := false
+	primary := b.signaling
+	independentEndpoint := primary != nil || b.subAccountSignalingFactory != nil
 	if index := b.publishedSubAccountIndex(id); index >= 0 {
 		current := b.subAnnouncers[index]
 		if !sameSignaling(current.signaling, lost) && current.signaling != nil && current.signaling.Context().Err() == nil {
+			b.mu.Unlock()
 			return nil
 		}
-		_ = b.closePublishedSubAccount(current)
+		previous = current
+		hadPrevious = true
 		b.subAnnouncers = append(b.subAnnouncers[:index], b.subAnnouncers[index+1:]...)
 		delete(b.subAnnouncersByID, id)
+	}
+	b.mu.Unlock()
+
+	if hadPrevious {
+		_ = b.closePublishedSubAccount(previous)
 	}
 
 	status, err := b.status(b.ctx)
 	if err != nil {
 		return fmt.Errorf("resolve session status: %w", err)
 	}
-	if err := b.startSubAccountBounded(b.ctx, account, status); err != nil {
+	timeout := b.subAccountStartTimeout
+	if timeout <= 0 {
+		timeout = 90 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(b.ctx, timeout)
+	prepared, err := b.prepareSubAccount(ctx, account, status, independentEndpoint, primary)
+	cancel()
+	if err != nil {
 		return fmt.Errorf("restart sub-account: %w", err)
 	}
+
+	b.mu.Lock()
+	if b.ctx.Err() != nil || !b.started {
+		b.mu.Unlock()
+		_ = b.closePublishedSubAccount(prepared)
+		return errors.New("broadcaster is shut down")
+	}
+	if sameSignaling(prepared.signaling, b.signaling) {
+		b.mu.Unlock()
+		// The prepared signaling now belongs to the primary lifecycle; dispose
+		// only the sub-account resources so rejecting it cannot close primary.
+		prepared.signaling = nil
+		_ = b.closePublishedSubAccount(prepared)
+		return errors.New("restart sub-account: prepared signaling matches the current primary signaling")
+	}
+	if index := b.publishedSubAccountIndex(id); index >= 0 {
+		current := b.subAnnouncers[index]
+		if current.signaling != nil && current.signaling.Context().Err() == nil {
+			b.mu.Unlock()
+			_ = b.closePublishedSubAccount(prepared)
+			return nil
+		}
+	}
+	b.retainPublishedSubAccount(prepared)
+	b.mu.Unlock()
 	return nil
 }
 
@@ -2209,7 +2307,7 @@ func (b *Broadcaster) recreateSession() error {
 func (b *Broadcaster) Update(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if !b.started {
+	if !b.started || b.closing {
 		return errors.New("broadcaster not started")
 	}
 	status, err := b.status(ctx)
@@ -2333,10 +2431,19 @@ func xblClientCreated(client *xsapi.Client, created map[*xsapi.Client]struct{}) 
 // Close stops the listener and removes the Xbox session.
 func (b *Broadcaster) Close() error {
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	if b.closing {
+		state := b.closeState
+		b.mu.Unlock()
+		<-state.done
+		return state.err
+	}
 	if !b.started {
+		b.mu.Unlock()
 		return nil
 	}
+	b.closing = true
+	state := &broadcasterCloseState{done: make(chan struct{})}
+	b.closeState = state
 	b.cancel()
 	err := b.listener.Close()
 	err = errors.Join(err, b.cleanupPublishedSessions(false))
@@ -2345,9 +2452,22 @@ func (b *Broadcaster) Close() error {
 			err = errors.Join(err, c.Close())
 		}
 	}
+	done := b.done
+	b.mu.Unlock()
+
+	// A targeted sub-account reconnect may still be unwinding account network
+	// calls. Wait without b.mu so it can discard any prepared replacement.
+	b.reconnectWg.Wait()
 	err = errors.Join(err, b.closeCreatedXBLClients())
-	<-b.done
+	if done != nil {
+		<-done
+	}
+	b.mu.Lock()
 	b.started = false
+	b.closing = false
+	state.err = err
+	close(state.done)
+	b.mu.Unlock()
 	return err
 }
 

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -25,6 +25,49 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/room"
 )
 
+func TestBroadcasterStartRejectsClosingState(t *testing.T) {
+	b, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.closing = true
+
+	err = b.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "closing") {
+		t.Fatalf("Start() error = %v, want closing-state rejection", err)
+	}
+}
+
+func TestBroadcasterConcurrentCloseWaitsForActiveShutdown(t *testing.T) {
+	state := &broadcasterCloseState{done: make(chan struct{})}
+	b := &Broadcaster{closing: true, closeState: state}
+	want := errors.New("close failed")
+	result := make(chan error, 1)
+	go func() {
+		result <- b.Close()
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("concurrent Close() returned before shutdown completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	// Simulate a later lifecycle generation replacing the broadcaster's state.
+	// The waiter must still read the result from the generation it captured.
+	b.mu.Lock()
+	b.closeState = &broadcasterCloseState{done: make(chan struct{})}
+	b.mu.Unlock()
+	state.err = want
+	close(state.done)
+	if err := <-result; !errors.Is(err, want) {
+		t.Fatalf("concurrent Close() error = %v, want %v", err, want)
+	}
+}
+
 func TestBroadcasterStartSubAccountsMutuallyFollowsBeforePublish(t *testing.T) {
 	var calls []string
 	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/config.go
+++ b/config.go
@@ -53,7 +53,8 @@ type Config struct {
 	// FriendHistory records player activity for friend expiry.
 	FriendHistory HistoryStore
 	// SubAccounts contains additional accounts that publish independently owned
-	// MPSD sessions for the same NetherNet listener.
+	// MPSD sessions and account-authenticated NetherNet listeners for the same
+	// target server.
 	SubAccounts []SubAccountConfig
 
 	// Signaling is the NetherNet signaling connection used to accept clients.

--- a/signaling_connection.go
+++ b/signaling_connection.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/sandertv/gophertunnel/minecraft/p2p"
 	"github.com/sandertv/gophertunnel/minecraft/room"
+	"github.com/sandertv/gophertunnel/minecraft/service"
 )
 
 type signalingConnectionAnnouncer struct {
@@ -60,7 +61,22 @@ func (b *Broadcaster) signalingConnection(ctx context.Context, sig nethernet.Sig
 	if strings.TrimSpace(networkID) == "" {
 		return nil, errors.New("jsonrpc signaling connection: nethernet id is empty")
 	}
-	pmsgID, err := b.playerMessagingID(ctx)
+	src, err := b.minecraftTokenSource(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return signalingConnectionWithTokenSource(ctx, sig, src)
+}
+
+func signalingConnectionWithTokenSource(ctx context.Context, sig nethernet.Signaling, src service.TokenSource) (*room.Connection, error) {
+	if sig == nil {
+		return nil, errors.New("jsonrpc signaling connection: signaling is nil")
+	}
+	networkID := sig.NetworkID()
+	if strings.TrimSpace(networkID) == "" {
+		return nil, errors.New("jsonrpc signaling connection: nethernet id is empty")
+	}
+	pmsgID, err := playerMessagingID(ctx, src)
 	if err != nil {
 		return nil, err
 	}
@@ -71,10 +87,9 @@ func (b *Broadcaster) signalingConnection(ctx context.Context, sig nethernet.Sig
 	}, nil
 }
 
-func (b *Broadcaster) playerMessagingID(ctx context.Context) (uuid.UUID, error) {
-	src, err := b.minecraftTokenSource(ctx)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("create minecraft token source for jsonrpc signaling: %w", err)
+func playerMessagingID(ctx context.Context, src service.TokenSource) (uuid.UUID, error) {
+	if src == nil {
+		return uuid.Nil, errors.New("create minecraft token source for jsonrpc signaling: token source is nil")
 	}
 	tok, err := src.ServiceToken(ctx)
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -78,12 +78,19 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 	}), nil
 }
 
-// subAccountStatus makes a sub-account's activity independently joinable
-// while preserving the primary session's advertised NetherNet connection and
+// subAccountStatus applies sub-account ownership while preserving the primary
 // world metadata.
 func subAccountStatus(status room.Status, xuid string) room.Status {
 	status.OwnerID = xuid
 	status.LevelID = accountLevelID(xuid)
+	return status
+}
+
+// subAccountStatusWithConnection also replaces discovery metadata with the
+// sub-account's account-authenticated signaling connection.
+func subAccountStatusWithConnection(status room.Status, xuid string, connection room.Connection) room.Status {
+	status = subAccountStatus(status, xuid)
+	status.SupportedConnections = []room.Connection{connection}
 	return status
 }
 

--- a/status.go
+++ b/status.go
@@ -23,6 +23,9 @@ import (
 var defaultRoomStatus = room.DefaultStatus()
 
 func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
+	b.statusMu.Lock()
+	defer b.statusMu.Unlock()
+
 	ownerID, err := b.primaryXUIDForStatus(ctx)
 	if err != nil {
 		return room.Status{}, err

--- a/subaccount_session_test.go
+++ b/subaccount_session_test.go
@@ -68,7 +68,7 @@ func TestBroadcasterStartSubAccountPublishesIndependentSessionAndSignaling(t *te
 	}
 	sub := &fakeAnnouncer{}
 	subSignaling := &fakeSignaling{networkID: "sub-nethernet"}
-	subListener := &trackedListener{}
+	subListener := newTrackedListener()
 	var ref mpsd.SessionReference
 	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host != "peoplehub.xboxlive.com" {
@@ -203,7 +203,7 @@ func TestBroadcasterSubAccountUpdateFailureDoesNotCountAsPrimaryFailure(t *testi
 func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	sub := &fakeAnnouncer{}
 	signaling := &fakeSignaling{}
-	listener := &trackedListener{}
+	listener := newTrackedListener()
 	b := &Broadcaster{subAnnouncers: []publishedSubAccount{{
 		id:        "sub1",
 		xuid:      "sub",
@@ -273,7 +273,7 @@ func TestBroadcasterRejectsPrimarySignalingForSubAccount(t *testing.T) {
 		},
 	}
 
-	_, err := b.subAccountSignalingFor(context.Background(), &SubAccountConfig{})
+	_, err := b.subAccountSignalingFor(context.Background(), &SubAccountConfig{}, primary)
 	if err == nil || !strings.Contains(err.Error(), "primary signaling instance") {
 		t.Fatalf("subAccountSignalingFor() error = %v, want shared-instance rejection", err)
 	}
@@ -296,7 +296,7 @@ func TestBroadcasterSubAccountTokenSetupHonoursStartupDeadline(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := b.subAccountSignalingFor(ctx, &SubAccountConfig{})
+		_, err := b.subAccountSignalingFor(ctx, &SubAccountConfig{}, nil)
 		done <- err
 	}()
 
@@ -337,12 +337,13 @@ func TestBroadcasterDetectsLostSubAccountSignaling(t *testing.T) {
 		}},
 	}
 
-	if got := b.sessionUnhealthyReason(); got != "sub-account sub1 signaling lost" {
-		t.Fatalf("sessionUnhealthyReason() = %q, want lost sub-account signaling", got)
+	id, signaling := b.lostSubAccountSignaling()
+	if id != "sub1" || signaling != b.subAnnouncers[0].signaling {
+		t.Fatalf("lostSubAccountSignaling() = (%q, %p), want sub1 signaling", id, signaling)
 	}
 }
 
-func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testing.T) {
+func TestBroadcasterReconnectsLostSubAccountWithoutRestartingPrimary(t *testing.T) {
 	lostCtx, lose := context.WithCancel(context.Background())
 	lose()
 	primary := &fakeSignaling{networkID: "primary-nethernet"}
@@ -350,8 +351,9 @@ func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testin
 	replacement := &fakeSignaling{networkID: "replacement-sub-nethernet"}
 	oldAnnouncer := &fakeAnnouncer{}
 	newAnnouncer := &fakeAnnouncer{}
-	oldListener := &trackedListener{}
-	newListener := &trackedListener{}
+	oldListener := newTrackedListener()
+	newListener := newTrackedListener()
+	primaryAnnouncer := &fakeAnnouncer{}
 	connection := room.Connection{
 		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
 		NetherNetID:    "replacement-sub-nethernet",
@@ -361,10 +363,9 @@ func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testin
 		log:               testBroadcasterLogger(),
 		signaling:         primary,
 		sessionConnection: &room.Connection{ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC, NetherNetID: "primary-nethernet", PmsgID: uuid.New()},
-		announcer:         &fakeAnnouncer{},
+		announcer:         primaryAnnouncer,
 		started:           true,
 		conf: Config{
-			Signaling: primary,
 			XBLClient: &xsapi.Client{},
 			XUID:      "same",
 			Status:    Status{HostName: "Host", WorldName: "World"},
@@ -403,8 +404,25 @@ func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testin
 		t.Fatal("checkSessionHealth() = false, want lost sub-account signaling recovery")
 	}
 
+	deadline := time.Now().Add(time.Second)
+	for {
+		b.mu.Lock()
+		replaced := len(b.subAnnouncers) == 1 && b.subAnnouncers[0].signaling == replacement && b.subAnnouncers[0].listener == newListener
+		b.mu.Unlock()
+		if replaced {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for targeted sub-account recovery")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
 	if !oldAnnouncer.Closed() || !oldListener.Closed() {
 		t.Fatalf("lost sub-account resources remain open: announcer=%v listener=%v", oldAnnouncer.Closed(), oldListener.Closed())
+	}
+	if primaryAnnouncer.Closed() || primary.closed {
+		t.Fatal("targeted sub-account recovery restarted the primary endpoint")
 	}
 	if len(b.subAnnouncers) != 1 || b.subAnnouncers[0].signaling != replacement || b.subAnnouncers[0].listener != newListener {
 		t.Fatalf("sub-account endpoint was not replaced: %#v", b.subAnnouncers)
@@ -412,11 +430,149 @@ func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testin
 	if b.subAnnouncersByID["sub1"] == nil || b.subAnnouncersByID["sub1"] == oldAnnouncer {
 		t.Fatal("sub-account announcer lookup was not replaced")
 	}
+	b.reconnectWg.Wait()
 
 	if err := b.cleanupPublishedSessions(false); err != nil {
 		t.Fatal(err)
 	}
 	b.acceptWg.Wait()
+}
+
+func TestBroadcasterRevalidatesPreparedSubAccountAgainstCurrentPrimary(t *testing.T) {
+	lostCtx, lose := context.WithCancel(context.Background())
+	lose()
+	oldPrimary := &fakeSignaling{networkID: "old-primary"}
+	newPrimary := &fakeSignaling{networkID: "new-primary"}
+	lost := &cancelableSignaling{ctx: lostCtx, networkID: "lost-sub"}
+	factoryStarted := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	b := &Broadcaster{
+		log:       testBroadcasterLogger(),
+		signaling: oldPrimary,
+		started:   true,
+		conf: Config{
+			XBLClient: &xsapi.Client{},
+			XUID:      "same",
+			Status:    Status{HostName: "Host", WorldName: "World"},
+			SubAccounts: []SubAccountConfig{{
+				ID:        "sub1",
+				Enabled:   true,
+				XBLClient: &xsapi.Client{},
+				XUID:      "same",
+			}},
+		},
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			xuid:      "same",
+			announcer: &fakeAnnouncer{},
+			signaling: lost,
+			listener:  newTrackedListener(),
+		}},
+		subAnnouncersByID: map[string]room.Announcer{"sub1": &fakeAnnouncer{}},
+		subAccountAnnouncerFactory: func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
+			return &fakeAnnouncer{}, nil
+		},
+		subAccountSignalingFactory: func(context.Context, *SubAccountConfig) (nethernet.Signaling, error) {
+			close(factoryStarted)
+			<-releaseFactory
+			return newPrimary, nil
+		},
+		subAccountConnectionFactory: func(context.Context, *SubAccountConfig, nethernet.Signaling) (*room.Connection, error) {
+			return &room.Connection{ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC, NetherNetID: "new-primary", PmsgID: uuid.New()}, nil
+		},
+		subAccountListenerFactory: func(nethernet.Signaling, room.Status) (net.Listener, error) {
+			return newTrackedListener(), nil
+		},
+	}
+	b.ctx, b.cancel = context.WithCancel(context.Background())
+	defer b.cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- b.recreateSubAccount("sub1", lost)
+	}()
+	select {
+	case <-factoryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sub-account signaling preparation did not start")
+	}
+	b.mu.Lock()
+	b.signaling = newPrimary
+	b.mu.Unlock()
+	close(releaseFactory)
+
+	err := <-result
+	if err == nil || !strings.Contains(err.Error(), "matches the current primary") {
+		t.Fatalf("recreateSubAccount() error = %v, want current-primary rejection", err)
+	}
+	if newPrimary.closed {
+		t.Fatal("rejecting the now-primary signaling closed the primary endpoint")
+	}
+}
+
+func TestBroadcasterSubAccountReconnectDoesNotBlockHealthLoopOrMutex(t *testing.T) {
+	lostCtx, lose := context.WithCancel(context.Background())
+	lose()
+	reconnectStarted := make(chan struct{})
+	b := &Broadcaster{
+		log:       testBroadcasterLogger(),
+		signaling: &fakeSignaling{networkID: "primary-nethernet"},
+		started:   true,
+		conf: Config{
+			XUID: "same",
+			SubAccounts: []SubAccountConfig{{
+				ID:        "sub1",
+				Enabled:   true,
+				XBLClient: &xsapi.Client{},
+				XUID:      "same",
+			}},
+		},
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			signaling: &cancelableSignaling{ctx: lostCtx, networkID: "lost-sub-nethernet"},
+			announcer: &fakeAnnouncer{},
+			listener:  newTrackedListener(),
+		}},
+		subAccountSignalingFactory: func(ctx context.Context, _ *SubAccountConfig) (nethernet.Signaling, error) {
+			close(reconnectStarted)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	b.ctx, b.cancel = context.WithCancel(context.Background())
+
+	returned := make(chan bool, 1)
+	go func() {
+		returned <- b.checkSessionHealth()
+	}()
+	select {
+	case unhealthy := <-returned:
+		if !unhealthy {
+			t.Fatal("checkSessionHealth() = false, want recovery scheduled")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("checkSessionHealth blocked on sub-account reconnection")
+	}
+	select {
+	case <-reconnectStarted:
+	case <-time.After(time.Second):
+		t.Fatal("sub-account reconnection did not start")
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		b.mu.Lock()
+		b.mu.Unlock()
+		close(lockAcquired)
+	}()
+	select {
+	case <-lockAcquired:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("sub-account reconnection held the broadcaster mutex during network work")
+	}
+
+	b.cancel()
+	b.reconnectWg.Wait()
 }
 
 func TestBroadcasterSkipsDuplicateIDsBeforePublishing(t *testing.T) {
@@ -462,15 +618,24 @@ func TestBroadcasterSkipsDuplicateIDsBeforePublishing(t *testing.T) {
 type trackedListener struct {
 	mu     sync.Mutex
 	closed bool
+	done   chan struct{}
+}
+
+func newTrackedListener() *trackedListener {
+	return &trackedListener{done: make(chan struct{})}
 }
 
 func (l *trackedListener) Accept() (net.Conn, error) {
+	<-l.done
 	return nil, net.ErrClosed
 }
 
 func (l *trackedListener) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if !l.closed {
+		close(l.done)
+	}
 	l.closed = true
 	return nil
 }

--- a/subaccount_session_test.go
+++ b/subaccount_session_test.go
@@ -4,20 +4,31 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/df-mc/go-nethernet"
 	"github.com/df-mc/go-xsapi/v2"
 	"github.com/df-mc/go-xsapi/v2/mpsd"
 	"github.com/google/uuid"
 	"github.com/sandertv/gophertunnel/minecraft/p2p"
 	"github.com/sandertv/gophertunnel/minecraft/room"
+	"github.com/sandertv/gophertunnel/minecraft/service"
 )
 
 func TestSubAccountStatusOwnsIndependentActivity(t *testing.T) {
-	connection := room.Connection{
+	primaryConnection := room.Connection{
 		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
-		NetherNetID:    "shared-nethernet",
+		NetherNetID:    "primary-nethernet",
+		PmsgID:         uuid.New(),
+	}
+	subConnection := room.Connection{
+		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
+		NetherNetID:    "sub-nethernet",
 		PmsgID:         uuid.New(),
 	}
 	primary := room.Status{
@@ -25,10 +36,10 @@ func TestSubAccountStatusOwnsIndependentActivity(t *testing.T) {
 		LevelID:              accountLevelID("primary"),
 		HostName:             "Lunar",
 		WorldName:            "Lunar",
-		SupportedConnections: []room.Connection{connection},
+		SupportedConnections: []room.Connection{primaryConnection},
 	}
 
-	got := subAccountStatus(primary, "sub")
+	got := subAccountStatusWithConnection(primary, "sub", subConnection)
 
 	if got.OwnerID != "sub" {
 		t.Fatalf("OwnerID = %q, want sub", got.OwnerID)
@@ -36,21 +47,28 @@ func TestSubAccountStatusOwnsIndependentActivity(t *testing.T) {
 	if got.LevelID != accountLevelID("sub") {
 		t.Fatalf("LevelID = %q, want account-specific level id", got.LevelID)
 	}
-	if fmt.Sprint(got.SupportedConnections) != fmt.Sprint(primary.SupportedConnections) {
-		t.Fatalf("SupportedConnections = %#v, want shared primary connection %#v", got.SupportedConnections, primary.SupportedConnections)
+	if len(got.SupportedConnections) != 1 || got.SupportedConnections[0] != subConnection {
+		t.Fatalf("SupportedConnections = %#v, want independent sub-account connection %#v", got.SupportedConnections, subConnection)
 	}
 	if primary.OwnerID != "primary" || primary.LevelID != accountLevelID("primary") {
 		t.Fatalf("subAccountStatus mutated primary status: %#v", primary)
 	}
 }
 
-func TestBroadcasterStartSubAccountPublishesIndependentSession(t *testing.T) {
-	connection := room.Connection{
+func TestBroadcasterStartSubAccountPublishesIndependentSessionAndSignaling(t *testing.T) {
+	primaryConnection := room.Connection{
 		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
-		NetherNetID:    "shared-nethernet",
+		NetherNetID:    "primary-nethernet",
+		PmsgID:         uuid.New(),
+	}
+	subConnection := room.Connection{
+		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
+		NetherNetID:    "sub-nethernet",
 		PmsgID:         uuid.New(),
 	}
 	sub := &fakeAnnouncer{}
+	subSignaling := &fakeSignaling{networkID: "sub-nethernet"}
+	subListener := &trackedListener{}
 	var ref mpsd.SessionReference
 	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Host != "peoplehub.xboxlive.com" {
@@ -60,8 +78,10 @@ func TestBroadcasterStartSubAccountPublishesIndependentSession(t *testing.T) {
 	})}
 	b := &Broadcaster{
 		log:               testBroadcasterLogger(),
+		ctx:               context.Background(),
+		signaling:         &fakeSignaling{networkID: "primary-nethernet"},
 		sessionRef:        mpsd.SessionReference{ServiceConfigID: serviceConfigUUID, TemplateName: TemplateName, Name: "PRIMARY"},
-		sessionConnection: &connection,
+		sessionConnection: &primaryConnection,
 		conf: Config{
 			XBLClient:  &xsapi.Client{},
 			XUID:       "primary",
@@ -70,6 +90,15 @@ func TestBroadcasterStartSubAccountPublishesIndependentSession(t *testing.T) {
 		subAccountAnnouncerFactory: func(_ context.Context, _ SubAccountConfig, got mpsd.SessionReference) (room.Announcer, error) {
 			ref = got
 			return sub, nil
+		},
+		subAccountSignalingFactory: func(context.Context, *SubAccountConfig) (nethernet.Signaling, error) {
+			return subSignaling, nil
+		},
+		subAccountConnectionFactory: func(context.Context, *SubAccountConfig, nethernet.Signaling) (*room.Connection, error) {
+			return &subConnection, nil
+		},
+		subAccountListenerFactory: func(nethernet.Signaling, room.Status) (net.Listener, error) {
+			return subListener, nil
 		},
 	}
 	account := &SubAccountConfig{ID: "sub1", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "sub"}
@@ -86,11 +115,21 @@ func TestBroadcasterStartSubAccountPublishesIndependentSession(t *testing.T) {
 	if got.OwnerID != "sub" || got.LevelID != accountLevelID("sub") {
 		t.Fatalf("sub-account published primary-owned status: %#v", got)
 	}
-	if len(got.SupportedConnections) != 1 || got.SupportedConnections[0] != connection {
-		t.Fatalf("sub-account connection = %#v, want shared connection %#v", got.SupportedConnections, connection)
+	if len(got.SupportedConnections) != 1 || got.SupportedConnections[0] != subConnection {
+		t.Fatalf("sub-account connection = %#v, want independent connection %#v", got.SupportedConnections, subConnection)
 	}
 	if b.subAnnouncersByID["sub1"] == nil {
 		t.Fatal("sub-account announcer was not retained for updates and invites")
+	}
+	if len(b.subAnnouncers) != 1 || b.subAnnouncers[0].signaling != subSignaling || b.subAnnouncers[0].listener != subListener {
+		t.Fatalf("sub-account endpoint not retained: %#v", b.subAnnouncers)
+	}
+	if err := b.cleanupPublishedSessions(false); err != nil {
+		t.Fatal(err)
+	}
+	b.acceptWg.Wait()
+	if !sub.Closed() || !subSignaling.closed || !subListener.Closed() {
+		t.Fatalf("cleanup incomplete: announcer=%v signaling=%v listener=%v", sub.Closed(), subSignaling.closed, subListener.Closed())
 	}
 }
 
@@ -163,10 +202,14 @@ func TestBroadcasterSubAccountUpdateFailureDoesNotCountAsPrimaryFailure(t *testi
 
 func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	sub := &fakeAnnouncer{}
+	signaling := &fakeSignaling{}
+	listener := &trackedListener{}
 	b := &Broadcaster{subAnnouncers: []publishedSubAccount{{
 		id:        "sub1",
 		xuid:      "sub",
 		announcer: sub,
+		signaling: signaling,
+		listener:  listener,
 	}}}
 
 	if err := b.cleanupPublishedSessions(false); err != nil {
@@ -175,9 +218,205 @@ func TestBroadcasterCleanupClosesIndependentSubAccountSessions(t *testing.T) {
 	if !sub.Closed() {
 		t.Fatal("sub-account announcer was not closed")
 	}
+	if !signaling.closed || !listener.Closed() {
+		t.Fatalf("sub-account transport not closed: signaling=%v listener=%v", signaling.closed, listener.Closed())
+	}
 	if len(b.subAnnouncersByID) != 0 {
 		t.Fatalf("sub-account announcers retained after cleanup: %#v", b.subAnnouncersByID)
 	}
+}
+
+func TestBroadcasterSubAccountListenerFailureClosesPublishedResources(t *testing.T) {
+	announcer := &fakeAnnouncer{}
+	signaling := &fakeSignaling{networkID: "sub-nethernet"}
+	b := &Broadcaster{
+		log:       testBroadcasterLogger(),
+		ctx:       context.Background(),
+		signaling: &fakeSignaling{networkID: "primary-nethernet"},
+		conf: Config{
+			XBLClient: &xsapi.Client{},
+			XUID:      "primary",
+		},
+		subAccountAnnouncerFactory: func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
+			return announcer, nil
+		},
+		subAccountSignalingFactory: func(context.Context, *SubAccountConfig) (nethernet.Signaling, error) {
+			return signaling, nil
+		},
+		subAccountConnectionFactory: func(context.Context, *SubAccountConfig, nethernet.Signaling) (*room.Connection, error) {
+			return &room.Connection{ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC, NetherNetID: "sub-nethernet", PmsgID: uuid.New()}, nil
+		},
+		subAccountListenerFactory: func(nethernet.Signaling, room.Status) (net.Listener, error) {
+			return nil, errors.New("listen failed")
+		},
+	}
+	account := &SubAccountConfig{ID: "sub1", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "primary"}
+
+	err := b.startSubAccount(context.Background(), account, room.Status{})
+	if err == nil || !strings.Contains(err.Error(), "listen failed") {
+		t.Fatalf("startSubAccount() error = %v, want listener failure", err)
+	}
+	if !announcer.Closed() || !signaling.closed {
+		t.Fatalf("failed startup leaked resources: announcer=%v signaling=%v", announcer.Closed(), signaling.closed)
+	}
+	if len(b.subAnnouncers) != 0 {
+		t.Fatalf("failed sub-account retained: %#v", b.subAnnouncers)
+	}
+}
+
+func TestBroadcasterRejectsPrimarySignalingForSubAccount(t *testing.T) {
+	primary := &fakeSignaling{networkID: "primary-nethernet"}
+	b := &Broadcaster{
+		signaling: primary,
+		subAccountSignalingFactory: func(context.Context, *SubAccountConfig) (nethernet.Signaling, error) {
+			return primary, nil
+		},
+	}
+
+	_, err := b.subAccountSignalingFor(context.Background(), &SubAccountConfig{})
+	if err == nil || !strings.Contains(err.Error(), "primary signaling instance") {
+		t.Fatalf("subAccountSignalingFor() error = %v, want shared-instance rejection", err)
+	}
+	if primary.closed {
+		t.Fatal("rejecting a shared signaling instance closed the primary endpoint")
+	}
+}
+
+func TestBroadcasterSubAccountTokenSetupHonoursStartupDeadline(t *testing.T) {
+	b := &Broadcaster{
+		ctx:  context.Background(),
+		conf: Config{SignalingMode: SignalingModeJSONRPC},
+		subAccountMinecraftTokenSourceFactory: func(ctx context.Context, _ *SubAccountConfig) (service.TokenSource, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.subAccountSignalingFor(ctx, &SubAccountConfig{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("subAccountSignalingFor() error = %v, want context deadline exceeded", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sub-account token setup ignored the startup deadline")
+	}
+}
+
+func TestBroadcasterSubAccountConnectionUsesSubAccountPMID(t *testing.T) {
+	pmid := uuid.New()
+	b := &Broadcaster{conf: Config{SignalingMode: SignalingModeJSONRPC}}
+	account := &SubAccountConfig{
+		MinecraftTokenSource: minecraftTokenSourceWithPMID{pmid: pmid},
+	}
+
+	connection, err := b.subAccountConnection(context.Background(), account, &fakeSignaling{networkID: "sub-nethernet"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if connection.NetherNetID != "sub-nethernet" || connection.PmsgID != pmid {
+		t.Fatalf("connection = %#v, want sub-account network id and PMID", connection)
+	}
+}
+
+func TestBroadcasterDetectsLostSubAccountSignaling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	b := &Broadcaster{
+		announcer: &room.XBLAnnouncer{Session: &mpsd.Session{}},
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			signaling: &cancelableSignaling{ctx: ctx, networkID: "sub-nethernet"},
+		}},
+	}
+
+	if got := b.sessionUnhealthyReason(); got != "sub-account sub1 signaling lost" {
+		t.Fatalf("sessionUnhealthyReason() = %q, want lost sub-account signaling", got)
+	}
+}
+
+func TestBroadcasterReconnectsLostSubAccountWithStaticPrimarySignaling(t *testing.T) {
+	lostCtx, lose := context.WithCancel(context.Background())
+	lose()
+	primary := &fakeSignaling{networkID: "primary-nethernet"}
+	lost := &cancelableSignaling{ctx: lostCtx, networkID: "lost-sub-nethernet"}
+	replacement := &fakeSignaling{networkID: "replacement-sub-nethernet"}
+	oldAnnouncer := &fakeAnnouncer{}
+	newAnnouncer := &fakeAnnouncer{}
+	oldListener := &trackedListener{}
+	newListener := &trackedListener{}
+	connection := room.Connection{
+		ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC,
+		NetherNetID:    "replacement-sub-nethernet",
+		PmsgID:         uuid.New(),
+	}
+	b := &Broadcaster{
+		log:               testBroadcasterLogger(),
+		signaling:         primary,
+		sessionConnection: &room.Connection{ConnectionType: p2p.ConnectionTypeSignalingOverJSONRPC, NetherNetID: "primary-nethernet", PmsgID: uuid.New()},
+		announcer:         &fakeAnnouncer{},
+		started:           true,
+		conf: Config{
+			Signaling: primary,
+			XBLClient: &xsapi.Client{},
+			XUID:      "same",
+			Status:    Status{HostName: "Host", WorldName: "World"},
+			SubAccounts: []SubAccountConfig{{
+				ID:        "sub1",
+				Enabled:   true,
+				XBLClient: &xsapi.Client{},
+				XUID:      "same",
+			}},
+		},
+		subAnnouncers: []publishedSubAccount{{
+			id:        "sub1",
+			xuid:      "same",
+			announcer: oldAnnouncer,
+			signaling: lost,
+			listener:  oldListener,
+		}},
+		subAnnouncersByID: map[string]room.Announcer{"sub1": oldAnnouncer},
+		subAccountAnnouncerFactory: func(context.Context, SubAccountConfig, mpsd.SessionReference) (room.Announcer, error) {
+			return newAnnouncer, nil
+		},
+		subAccountSignalingFactory: func(context.Context, *SubAccountConfig) (nethernet.Signaling, error) {
+			return replacement, nil
+		},
+		subAccountConnectionFactory: func(context.Context, *SubAccountConfig, nethernet.Signaling) (*room.Connection, error) {
+			return &connection, nil
+		},
+		subAccountListenerFactory: func(nethernet.Signaling, room.Status) (net.Listener, error) {
+			return newListener, nil
+		},
+	}
+	b.ctx, b.cancel = context.WithCancel(context.Background())
+	defer b.cancel()
+
+	if !b.checkSessionHealth() {
+		t.Fatal("checkSessionHealth() = false, want lost sub-account signaling recovery")
+	}
+
+	if !oldAnnouncer.Closed() || !oldListener.Closed() {
+		t.Fatalf("lost sub-account resources remain open: announcer=%v listener=%v", oldAnnouncer.Closed(), oldListener.Closed())
+	}
+	if len(b.subAnnouncers) != 1 || b.subAnnouncers[0].signaling != replacement || b.subAnnouncers[0].listener != newListener {
+		t.Fatalf("sub-account endpoint was not replaced: %#v", b.subAnnouncers)
+	}
+	if b.subAnnouncersByID["sub1"] == nil || b.subAnnouncersByID["sub1"] == oldAnnouncer {
+		t.Fatal("sub-account announcer lookup was not replaced")
+	}
+
+	if err := b.cleanupPublishedSessions(false); err != nil {
+		t.Fatal(err)
+	}
+	b.acceptWg.Wait()
 }
 
 func TestBroadcasterSkipsDuplicateIDsBeforePublishing(t *testing.T) {
@@ -218,4 +457,30 @@ func TestBroadcasterSkipsDuplicateIDsBeforePublishing(t *testing.T) {
 	if second.Closed() {
 		t.Fatal("duplicate-ID session was published and retained")
 	}
+}
+
+type trackedListener struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (l *trackedListener) Accept() (net.Conn, error) {
+	return nil, net.ErrClosed
+}
+
+func (l *trackedListener) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.closed = true
+	return nil
+}
+
+func (l *trackedListener) Addr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+func (l *trackedListener) Closed() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.closed
 }


### PR DESCRIPTION
## What changed

- create an account-authenticated Minecraft messaging signaling connection for each enabled subaccount
- advertise each subaccount's own NetherNet ID and player-messaging ID in its independent MPSD activity
- run a dedicated NetherNet listener per subaccount while keeping the same transfer target
- clean up subaccount listeners and signaling connections with their sessions
- recover a failed subaccount endpoint independently when the primary signaling instance is static
- keep subaccount authentication inside the configured startup deadline

## Why

Independent MPSD sessions, owners, and level IDs were not sufficient: after a clean restart, only one of the primary/subaccount profiles would be joinable, and which one won could flip. Diagnostics showed the remaining shared discovery identity was the NetherNet/player-messaging signaling pair, so Minecraft was effectively collapsing the activities onto one endpoint.

Each published profile now has a distinct, account-authenticated signaling identity and listener.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`
- independent Codex review: no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sub-accounts can now publish independent activity sessions with their own authenticated signaling connections and listeners.
  * Multiple broadcaster profiles can remain joinable simultaneously for the same target server.
  * Sub-account connections automatically recover when signaling is interrupted, without disrupting the primary session.

* **Documentation**
  * Expanded configuration guidance for primary and sub-account token cache paths and independent activity publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->