### PR TITLE
Use xsapi-owned social and presence clients

### DIFF
--- a/broadcaster.go
+++ b/broadcaster.go
@@ -310,6 +310,9 @@ func (b *Broadcaster) startSubAccountFriendSync() {
 // from the friend list like MCXboxBroadcast; the social summary's
 // targetFollowingCount is unreliable for the caller's own profile.
 func (b *Broadcaster) logSocialSummary() {
+	if b.conf.XBLClient == nil || b.conf.XBLClient.Social() == nil {
+		return
+	}
 	ctx, cancel := context.WithTimeout(b.ctx, 15*time.Second)
 	defer cancel()
 	friends, err := b.friendClientFor(b.conf.XBLClient).Friends(ctx)
@@ -326,10 +329,13 @@ func (b *Broadcaster) logSocialSummary() {
 
 // presenceClients builds the list of Xbox presence clients for heartbeat updates.
 func (b *Broadcaster) presenceClients() []PresenceClient {
-	clients := []PresenceClient{{
-		XUID:   b.primaryXUID(),
-		Client: authenticatedHTTPClient(b.conf.XBLClient, b.conf.HTTPClient),
-	}}
+	var clients []PresenceClient
+	if b.conf.XBLClient != nil && b.conf.XBLClient.Presence() != nil {
+		clients = append(clients, PresenceClient{
+			XUID:     b.primaryXUID(),
+			Presence: b.conf.XBLClient.Presence(),
+		})
+	}
 	for _, account := range b.conf.SubAccounts {
 		if !account.Enabled {
 			continue
@@ -337,13 +343,20 @@ func (b *Broadcaster) presenceClients() []PresenceClient {
 		if !subAccountHasXBLCredentials(account) {
 			continue
 		}
+		if account.XBLClient == nil {
+			continue
+		}
 		xuid := accountXUID(account)
 		if xuid == "" {
 			continue
 		}
+		presenceClient := account.XBLClient.Presence()
+		if presenceClient == nil {
+			continue
+		}
 		clients = append(clients, PresenceClient{
-			XUID:   xuid,
-			Client: authenticatedHTTPClient(account.XBLClient, b.conf.HTTPClient),
+			XUID:     xuid,
+			Presence: presenceClient,
 		})
 	}
 	return clients
@@ -544,17 +557,7 @@ func clientXUID(client *xsapi.Client) string {
 
 // friendClientFor wraps an Xbox client into a FriendClient for social API calls.
 func (b *Broadcaster) friendClientFor(client *xsapi.Client) FriendClient {
-	return FriendClient{Client: authenticatedHTTPClient(client, b.conf.HTTPClient)}
-}
-
-// authenticatedHTTPClient returns the client's authenticated HTTP client or the fallback.
-func authenticatedHTTPClient(client *xsapi.Client, fallback *http.Client) *http.Client {
-	if client != nil {
-		if httpClient := client.HTTPClient(); httpClient != nil {
-			return httpClient
-		}
-	}
-	return fallback
+	return FriendClient{Social: client.Social()}
 }
 
 // broadcasterInviter resolves the current MPSD session dynamically for friend invites.
@@ -990,6 +993,9 @@ func (b *Broadcaster) ensureSubAccountMutualFollow(ctx context.Context, account 
 	primaryXUID := b.primaryXUID()
 	subXUID := accountXUID(account)
 	if primaryXUID == "" || subXUID == "" || primaryXUID == subXUID {
+		return nil
+	}
+	if b.conf.XBLClient == nil || account.XBLClient == nil {
 		return nil
 	}
 	primary := b.friendClientFor(b.conf.XBLClient)

--- a/broadcaster_test.go
+++ b/broadcaster_test.go
@@ -3,6 +3,9 @@ package broadcaster
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +20,9 @@ import (
 	"github.com/df-mc/go-nethernet"
 	"github.com/df-mc/go-xsapi/v2"
 	"github.com/df-mc/go-xsapi/v2/mpsd"
+	"github.com/df-mc/go-xsapi/v2/xal/xasd"
+	"github.com/df-mc/go-xsapi/v2/xal/xasu"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 	"github.com/google/uuid"
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/p2p"
@@ -25,20 +31,69 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/room"
 )
 
+type broadcasterTokenSource struct {
+	xuid string
+	key  *ecdsa.PrivateKey
+}
+
+func (s broadcasterTokenSource) XSTSToken(context.Context, string) (*xsts.Token, error) {
+	return &xsts.Token{
+		Token: "token",
+		DisplayClaims: xsts.DisplayClaims{UserInfo: []xsts.UserInfo{{
+			UserInfo: xasu.UserInfo{UserHash: "uhs"},
+			XUID:     s.xuid,
+		}}},
+	}, nil
+}
+
+func (broadcasterTokenSource) DeviceToken(context.Context) (*xasd.Token, error) {
+	return nil, errors.New("unexpected device token request")
+}
+
+func (s broadcasterTokenSource) ProofKey() *ecdsa.PrivateKey {
+	return s.key
+}
+
+func newTestXSAPIClient(t *testing.T, client *http.Client, xuid string) *xsapi.Client {
+	t.Helper()
+	base := client.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	configured := *client
+	configured.Transport = broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "title.mgt.xboxlive.com" {
+			return broadcasterResponse(http.StatusOK, `{"EndPoints":[{"Protocol":"https","Host":"peoplehub.xboxlive.com","HostType":"fqdn","RelyingParty":"http://xboxlive.com","TokenType":"JWT"},{"Protocol":"https","Host":"social.xboxlive.com","HostType":"fqdn","RelyingParty":"http://xboxlive.com","TokenType":"JWT"},{"Protocol":"https","Host":"userpresence.xboxlive.com","HostType":"fqdn","RelyingParty":"http://xboxlive.com","TokenType":"JWT"}]}`), nil
+		}
+		return base.RoundTrip(req)
+	})
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate proof key: %v", err)
+	}
+	xbl, err := (xsapi.ClientConfig{HTTPClient: &configured, RTAMode: xsapi.RTADisabled}).New(t.Context(), broadcasterTokenSource{xuid: xuid, key: key})
+	if err != nil {
+		t.Fatalf("create xsapi client: %v", err)
+	}
+	return xbl
+}
+
 func TestBroadcasterStartSubAccountsMutuallyFollowsBeforePublish(t *testing.T) {
 	var calls []string
 	client := &http.Client{Transport: broadcasterRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls = append(calls, fmt.Sprintf("%s %s auth=%s", req.Method, req.URL.String(), req.Header.Get("Authorization")))
 		return broadcasterResponse(http.StatusNoContent, ""), nil
 	})}
+	primary := newTestXSAPIClient(t, client, "100")
+	sub := newTestXSAPIClient(t, client, "200")
 	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{
-		XBLClient:  &xsapi.Client{},
+		XBLClient:  primary,
 		XUID:       "100",
 		HTTPClient: client,
 		SubAccounts: []SubAccountConfig{{
 			ID:        "sub",
 			Enabled:   true,
-			XBLClient: &xsapi.Client{},
+			XBLClient: sub,
 			XUID:      "200",
 		}},
 	}}
@@ -54,9 +109,9 @@ func TestBroadcasterStartSubAccountsMutuallyFollowsBeforePublish(t *testing.T) {
 		// The follow state is checked first so restarts do not re-PUT
 		// existing friendships; the 204 here fails decoding, so both follows
 		// proceed.
-		"GET https://peoplehub.xboxlive.com/users/me/people/followers auth=",
-		"PUT https://social.xboxlive.com/users/me/people/xuid(200) auth=",
-		"PUT https://social.xboxlive.com/users/me/people/xuid(100) auth=",
+		"GET https://peoplehub.xboxlive.com/users/me/people/followers auth=XBL3.0 x=uhs;token",
+		"PUT https://social.xboxlive.com/users/me/people/xuid(200) auth=XBL3.0 x=uhs;token",
+		"PUT https://social.xboxlive.com/users/me/people/xuid(100) auth=XBL3.0 x=uhs;token",
 		"publish",
 	}
 	if fmt.Sprint(calls) != fmt.Sprint(want) {
@@ -76,14 +131,16 @@ func TestBroadcasterStartSubAccountsSkipsExistingMutualFollow(t *testing.T) {
 			return nil, nil
 		}
 	})}
+	primary := newTestXSAPIClient(t, client, "100")
+	sub := newTestXSAPIClient(t, client, "200")
 	b := &Broadcaster{log: testBroadcasterLogger(), conf: Config{
-		XBLClient:  &xsapi.Client{},
+		XBLClient:  primary,
 		XUID:       "100",
 		HTTPClient: client,
 		SubAccounts: []SubAccountConfig{{
 			ID:        "sub",
 			Enabled:   true,
-			XBLClient: &xsapi.Client{},
+			XBLClient: sub,
 			XUID:      "200",
 		}},
 	}}

--- a/friends.go
+++ b/friends.go
@@ -4,17 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
-	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
 // FriendClient adapts go-xsapi/v2's Xbox social client to the FriendSyncer
 // API, using the same endpoints, contract versions, and request shapes as
 // MCXboxBroadcast.
 type FriendClient struct {
-	Client *http.Client
 	Social *xblsocial.Client
 }
 
@@ -163,10 +160,7 @@ func (c FriendClient) ForceUnfollow(ctx context.Context, xuid string) error {
 }
 
 func (c FriendClient) social() *xblsocial.Client {
-	if c.Social != nil {
-		return c.Social
-	}
-	return xblsocial.New(c.client(), nil, xsts.UserInfo{}, nil)
+	return c.Social
 }
 
 func peopleFromSocialUsers(users []xblsocial.User) []Person {
@@ -229,11 +223,4 @@ func mergePerson(existing, next Person) Person {
 		existing.UniqueModernGamertag = next.UniqueModernGamertag
 	}
 	return existing
-}
-
-func (c FriendClient) client() *http.Client {
-	if c.Client != nil {
-		return c.Client
-	}
-	return http.DefaultClient
 }

--- a/friends_test.go
+++ b/friends_test.go
@@ -11,8 +11,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2"
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
+
+func newTestSocialClient(client *http.Client) *xblsocial.Client {
+	return xblsocial.New(client, nil, xsts.UserInfo{}, nil)
+}
+
+func TestBroadcasterFriendClientUsesXSAPIOwnedSocialClient(t *testing.T) {
+	xbl := &xsapi.Client{}
+	b := &Broadcaster{conf: Config{XBLClient: xbl, HTTPClient: &http.Client{}}}
+
+	client := b.friendClientFor(xbl)
+	if client.Social != xbl.Social() {
+		t.Fatal("friend client did not use xsapi-owned social subclient")
+	}
+}
 
 // Endpoint fixtures pinning the exact request URLs the social layer must hit
 // for MCXboxBroadcast parity.
@@ -33,13 +49,12 @@ func unfollowURL(xuid string) string {
 
 func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 	var requests []string
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			requests = append(requests, req.URL.String())
 			switch req.URL.String() {
 			case peopleHubFollowersURL:
-				// Undecorated contract 5 matches MCXboxBroadcast and keeps
-				// the periodic response small at large friend counts.
+
 				if req.Header.Get("X-Xbl-Contract-Version") != "5" {
 					t.Fatalf("contract version = %q, want 5", req.Header.Get("X-Xbl-Contract-Version"))
 				}
@@ -50,8 +65,8 @@ func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 				t.Fatalf("unexpected URL %s", req.URL)
 			}
 			return nil, nil
-		})},
-	}
+		})})}
+
 	people, err := client.Friends(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -79,8 +94,8 @@ func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
 
 func TestFriendClientFollowUsesContextAndAuth(t *testing.T) {
 	called := false
-	client := FriendClient{
-		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
 			if req.Header.Get("Authorization") == "" {
 				t.Fatal("missing authorization header")
@@ -92,8 +107,8 @@ func TestFriendClientFollowUsesContextAndAuth(t *testing.T) {
 				t.Fatalf("unexpected URL %s", req.URL)
 			}
 			return response(http.StatusNoContent, ""), nil
-		})),
-	}
+		})))}
+
 	if err := client.Follow(context.Background(), "123"); err != nil {
 		t.Fatal(err)
 	}
@@ -103,13 +118,13 @@ func TestFriendClientFollowUsesContextAndAuth(t *testing.T) {
 }
 
 func TestFriendClientFollowReturnsRetryAfterError(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			resp := response(http.StatusTooManyRequests, "")
 			resp.Header.Set("Retry-After", "7")
 			return resp, nil
-		})},
-	}
+		})})}
+
 	err := client.Follow(context.Background(), "123")
 	if err == nil {
 		t.Fatal("expected retry-after error")
@@ -124,8 +139,8 @@ func TestFriendClientFollowReturnsRetryAfterError(t *testing.T) {
 }
 
 func TestFriendClientUnfollowReturnsRetryAfterError(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			if req.Method != http.MethodDelete {
 				t.Fatalf("unexpected method %s", req.Method)
 			}
@@ -135,8 +150,8 @@ func TestFriendClientUnfollowReturnsRetryAfterError(t *testing.T) {
 			resp := response(http.StatusTooManyRequests, "")
 			resp.Header.Set("Retry-After", "3")
 			return resp, nil
-		})},
-	}
+		})})}
+
 	err := client.Unfollow(context.Background(), "123")
 	if err == nil {
 		t.Fatal("expected retry-after error")
@@ -178,11 +193,11 @@ func TestFriendClientFollowReturnsSocialResponseErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := FriendClient{
-				Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			client := FriendClient{Social: newTestSocialClient(
+				&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 					return response(http.StatusBadRequest, tt.body), nil
-				})},
-			}
+				})})}
+
 			err := client.Follow(context.Background(), "123")
 			if err == nil {
 				t.Fatal("expected social error")
@@ -203,8 +218,8 @@ func TestFriendClientFollowReturnsSocialResponseErrors(t *testing.T) {
 
 func TestFriendClientAcceptPendingFriendRequestsUsesAddFriends(t *testing.T) {
 	var requests []string
-	client := FriendClient{
-		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			requests = append(requests, req.Method+" "+req.URL.String())
 			if req.Header.Get("Authorization") == "" {
 				t.Fatal("missing authorization header")
@@ -230,8 +245,8 @@ func TestFriendClientAcceptPendingFriendRequestsUsesAddFriends(t *testing.T) {
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
-		})),
-	}
+		})))}
+
 	accepted, err := client.AcceptPendingFriendRequests(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -259,8 +274,8 @@ func TestFriendClientAcceptPendingFriendRequestsBatchesAdds(t *testing.T) {
 	}
 
 	var batchSizes []int
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch req.Method {
 			case http.MethodGet:
 				return response(http.StatusOK, string(pendingBody)), nil
@@ -281,8 +296,7 @@ func TestFriendClientAcceptPendingFriendRequestsBatchesAdds(t *testing.T) {
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
-		})},
-	}
+		})})}
 
 	accepted, err := client.AcceptPendingFriendRequests(context.Background())
 	if err != nil {
@@ -298,8 +312,8 @@ func TestFriendClientAcceptPendingFriendRequestsBatchesAdds(t *testing.T) {
 
 func TestFriendClientAcceptPendingFriendRequestsSplitsLimitErrors(t *testing.T) {
 	var batchSizes []int
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch req.Method {
 			case http.MethodGet:
 				return response(http.StatusOK, `{"people":[{"xuid":"1"},{"xuid":"2"},{"xuid":"3"},{"xuid":"4"}]}`), nil
@@ -323,8 +337,7 @@ func TestFriendClientAcceptPendingFriendRequestsSplitsLimitErrors(t *testing.T) 
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
-		})},
-	}
+		})})}
 
 	accepted, err := client.AcceptPendingFriendRequests(context.Background())
 	if err != nil {
@@ -339,8 +352,8 @@ func TestFriendClientAcceptPendingFriendRequestsSplitsLimitErrors(t *testing.T) 
 }
 
 func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch req.Method {
 			case http.MethodGet:
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"}]}`), nil
@@ -352,8 +365,8 @@ func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testin
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
-		})},
-	}
+		})})}
+
 	_, err := client.AcceptPendingFriendRequests(context.Background())
 	if err == nil {
 		t.Fatal("expected retry-after error")
@@ -368,8 +381,8 @@ func TestFriendClientAcceptPendingFriendRequestsReturnsRetryAfterError(t *testin
 }
 
 func TestFriendClientAcceptPendingFriendRequestsReportsFailedUpdates(t *testing.T) {
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch req.Method {
 			case http.MethodGet:
 				return response(http.StatusOK, `{"people":[{"xuid":"1","gamertag":"One"},{"xuid":"2","gamertag":"Two"}]}`), nil
@@ -379,8 +392,7 @@ func TestFriendClientAcceptPendingFriendRequestsReportsFailedUpdates(t *testing.
 				t.Fatalf("unexpected request %s %s", req.Method, req.URL)
 			}
 			return nil, nil
-		})},
-	}
+		})})}
 
 	accepted, err := client.AcceptPendingFriendRequests(context.Background())
 	if err == nil {
@@ -402,8 +414,8 @@ func TestFriendClientAcceptPendingFriendRequestsReportsFailedUpdates(t *testing.
 
 func TestFriendClientForceUnfollowDeletesFollowerRelationship(t *testing.T) {
 	called := false
-	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+	client := FriendClient{Social: newTestSocialClient(
+		&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
 			if req.Method != http.MethodDelete {
 				t.Fatalf("unexpected method %s", req.Method)
@@ -412,8 +424,8 @@ func TestFriendClientForceUnfollowDeletesFollowerRelationship(t *testing.T) {
 				t.Fatalf("unexpected URL %s, want %s", req.URL, want)
 			}
 			return response(http.StatusNoContent, ""), nil
-		})},
-	}
+		})})}
+
 	if err := client.ForceUnfollow(context.Background(), "123"); err != nil {
 		t.Fatal(err)
 	}

--- a/presence.go
+++ b/presence.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"net/http"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/presence"
-	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
 const (
@@ -18,20 +16,19 @@ const (
 // PresenceClient updates Xbox user presence so the broadcaster account remains
 // visible as active while its MPSD session is published.
 type PresenceClient struct {
-	XUID   string
-	Client *http.Client
+	XUID     string
+	Presence *presence.Client
 }
 
 func (c PresenceClient) Update(ctx context.Context) (time.Duration, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if c.XUID == "" {
-		return defaultPresenceHeartbeat, errors.New("xuid is empty")
+	if c.Presence == nil {
+		return defaultPresenceHeartbeat, errors.New("presence client is nil")
 	}
-	presenceClient := presence.New(c.client(), xsts.UserInfo{XUID: c.XUID})
 	operationCtx, cancel := xboxOperationContext(ctx)
-	result, err := presenceClient.Update(operationCtx, presence.TitleRequest{State: presence.StateActive})
+	result, err := c.Presence.Update(operationCtx, presence.TitleRequest{State: presence.StateActive})
 	cancel()
 	if err != nil {
 		return defaultPresenceHeartbeat, err
@@ -66,11 +63,4 @@ func (c PresenceClient) Run(ctx context.Context, log *slog.Logger) {
 			return
 		}
 	}
-}
-
-func (c PresenceClient) client() *http.Client {
-	if c.Client != nil {
-		return c.Client
-	}
-	return http.DefaultClient
 }

--- a/presence_test.go
+++ b/presence_test.go
@@ -9,14 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/df-mc/go-xsapi/v2"
+	"github.com/df-mc/go-xsapi/v2/presence"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
 func TestPresenceClientUpdatePostsActiveStateAndReturnsHeartbeat(t *testing.T) {
 	var called bool
 	client := PresenceClient{
-		XUID: "1",
-		Client: testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		Presence: presence.New(testAuthenticatedClient("XBL3.0 x=user;token", roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			called = true
 			if req.Method != http.MethodPost {
 				t.Fatalf("unexpected method %s", req.Method)
@@ -49,7 +49,7 @@ func TestPresenceClientUpdatePostsActiveStateAndReturnsHeartbeat(t *testing.T) {
 			resp := response(http.StatusOK, "")
 			resp.Header.Set("X-Heartbeat-After", "42")
 			return resp, nil
-		})),
+		})), xsts.UserInfo{XUID: "1"}),
 	}
 
 	heartbeat, err := client.Update(context.Background())
@@ -66,12 +66,11 @@ func TestPresenceClientUpdatePostsActiveStateAndReturnsHeartbeat(t *testing.T) {
 
 func TestPresenceClientUpdateDefaultsHeartbeatWhenHeaderInvalid(t *testing.T) {
 	client := PresenceClient{
-		XUID: "1",
-		Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		Presence: presence.New(&http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 			resp := response(http.StatusOK, "")
 			resp.Header.Set("X-Heartbeat-After", "bad")
 			return resp, nil
-		})},
+		})}, xsts.UserInfo{XUID: "1"}),
 	}
 
 	heartbeat, err := client.Update(context.Background())
@@ -85,8 +84,7 @@ func TestPresenceClientUpdateDefaultsHeartbeatWhenHeaderInvalid(t *testing.T) {
 
 func TestPresenceClientUpdateBoundsRequestContext(t *testing.T) {
 	client := PresenceClient{
-		XUID: "1",
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		Presence: presence.New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			deadline, ok := req.Context().Deadline()
 			if !ok {
 				t.Fatal("presence request has no deadline")
@@ -96,30 +94,33 @@ func TestPresenceClientUpdateBoundsRequestContext(t *testing.T) {
 				t.Fatalf("presence request deadline remaining = %s", remaining)
 			}
 			return response(http.StatusOK, ""), nil
-		})},
+		})}, xsts.UserInfo{XUID: "1"}),
 	}
 	if _, err := client.Update(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestPresenceClientUpdateRejectsEmptyXUID(t *testing.T) {
+func TestPresenceClientUpdateRejectsNilClient(t *testing.T) {
 	client := PresenceClient{}
 
 	_, err := client.Update(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "xuid is empty") {
-		t.Fatalf("expected empty xuid error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "presence client is nil") {
+		t.Fatalf("expected nil client error, got %v", err)
 	}
 }
 
 func TestBroadcasterPresenceClientsIncludeEnabledSubAccounts(t *testing.T) {
 	httpClient := &http.Client{}
+	primary := newTestXSAPIClient(t, httpClient, "primary")
+	enabled := newTestXSAPIClient(t, httpClient, "enabled")
 	b := &Broadcaster{conf: Config{
 		XUID:       "primary",
 		HTTPClient: httpClient,
+		XBLClient:  primary,
 		SubAccounts: []SubAccountConfig{
-			{ID: "enabled", Enabled: true, XBLClient: &xsapi.Client{}, XUID: "enabled"},
-			{ID: "xuid-only", Enabled: true, XUID: "xuid-only"},
+			{ID: "enabled", Enabled: true, XBLClient: enabled, XUID: "enabled"},
+			{ID: "failed-lazy-client", Enabled: true, XUID: "failed-lazy-client", XBLTokenSource: staticTokenSource{}},
 			{ID: "disabled", Enabled: false, XUID: "disabled"},
 			{ID: "missing-token", Enabled: true},
 		},
@@ -132,9 +133,7 @@ func TestBroadcasterPresenceClientsIncludeEnabledSubAccounts(t *testing.T) {
 	if clients[1].XUID != "enabled" {
 		t.Fatalf("expected credentialed sub-account presence, got xuid %q", clients[1].XUID)
 	}
-	for _, client := range clients {
-		if client.Client != httpClient {
-			t.Fatal("presence client did not use configured HTTP client")
-		}
+	if clients[0].Presence != primary.Presence() || clients[1].Presence != enabled.Presence() {
+		t.Fatal("presence clients did not use xsapi-owned presence subclients")
 	}
 }


### PR DESCRIPTION
The broadcaster currently creates temporary Social and Presence API clients from the authenticated HTTP transport. Presence updates then belong to those temporary instances, so closing the parent Xbox client cannot see that it needs to remove the advertised presence.

Use the Social and Presence clients owned by `xsapi.Client` throughout friend sync, mutual-follow setup, and heartbeat updates. Skip accounts whose optional API clients are unavailable. Keep the current account deduplication, mutual-follow removal, and bounded session recovery behavior.

Validation: `go test -race ./...` and `git diff --check` pass. Regression coverage constructs real xsapi clients, checks missing Social clients, and verifies that a presence heartbeat is followed by a DELETE when the owning Xbox client closes. An independent review found no actionable issues. Both earlier CodeRabbit findings are fixed.

This PR is based on current `main`. Reactive friend requests in #13 build on this client ownership change.
