### PR TITLE
Fix expired friend retention with block/unblock removal

### DIFF
--- a/friends.go
+++ b/friends.go
@@ -150,9 +150,17 @@ func (c FriendClient) Follow(ctx context.Context, xuid string) error {
 	return c.social().Follow(ctx, xuid)
 }
 
-// Unfollow removes the authenticated account's follow relationship for xuid.
+// Unfollow removes xuid from the authenticated account's friend list.
+//
+// Xbox's relationship delete only removes the caller's outgoing follow. A
+// block removes the user from the friend list on both sides; immediately
+// unblocking preserves the removal without leaving the user blocked.
 func (c FriendClient) Unfollow(ctx context.Context, xuid string) error {
-	return c.social().Unfollow(ctx, xuid)
+	socialClient := c.social()
+	if err := socialClient.Block(ctx, xuid); err != nil {
+		return err
+	}
+	return socialClient.Unblock(ctx, xuid)
 }
 
 // ForceUnfollow removes the follow relationship the user identified by xuid

--- a/friends_test.go
+++ b/friends_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	xblsocial "github.com/df-mc/go-xsapi/v2/social"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 )
 
 // Endpoint fixtures pinning the exact request URLs the social layer must hit
@@ -27,8 +28,8 @@ func followURL(xuid string) string {
 	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/xuid(%s)", xuid)
 }
 
-func unfollowURL(xuid string) string {
-	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/friends/v2/xuid(%s)?deleteRelationships=follows", xuid)
+func privacyBlockURL(xuid string) string {
+	return fmt.Sprintf("https://privacy.xboxlive.com/users/xuid(%s)/people/never", xuid)
 }
 
 func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {
@@ -123,30 +124,53 @@ func TestFriendClientFollowReturnsRetryAfterError(t *testing.T) {
 	}
 }
 
-func TestFriendClientUnfollowReturnsRetryAfterError(t *testing.T) {
+func TestFriendClientUnfollowReturnsBlockError(t *testing.T) {
 	client := FriendClient{
-		Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			if req.Method != http.MethodDelete {
+		Social: xblsocial.New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPut {
 				t.Fatalf("unexpected method %s", req.Method)
 			}
-			if req.URL.String() != unfollowURL("123") {
+			if req.URL.String() != privacyBlockURL("caller") {
 				t.Fatalf("unexpected URL %s", req.URL)
 			}
 			resp := response(http.StatusTooManyRequests, "")
 			resp.Header.Set("Retry-After", "3")
+			resp.Request = req
 			return resp, nil
-		})},
+		})}, nil, xsts.UserInfo{XUID: "caller"}, nil),
 	}
 	err := client.Unfollow(context.Background(), "123")
 	if err == nil {
-		t.Fatal("expected retry-after error")
+		t.Fatal("expected block error")
 	}
-	var responseErr *xblsocial.ResponseError
-	if !errors.As(err, &responseErr) {
-		t.Fatalf("expected social response error, got %T: %v", err, err)
+	if !strings.Contains(err.Error(), "PUT "+privacyBlockURL("caller")) {
+		t.Fatalf("error = %v, want privacy endpoint", err)
 	}
-	if responseErr.RetryAfter != 3*time.Second {
-		t.Fatalf("retry delay = %s, want 3s", responseErr.RetryAfter)
+}
+
+func TestFriendClientUnfollowBlocksAndUnblocks(t *testing.T) {
+	var methods []string
+	client := FriendClient{
+		Social: xblsocial.New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != privacyBlockURL("caller") {
+				t.Fatalf("unexpected URL %s", req.URL)
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.TrimSpace(string(body)) != `{"Xuid":"123"}` {
+				t.Fatalf("request body = %s, want target XUID", body)
+			}
+			methods = append(methods, req.Method)
+			return response(http.StatusOK, ""), nil
+		})}, nil, xsts.UserInfo{XUID: "caller"}, nil),
+	}
+	if err := client.Unfollow(context.Background(), "123"); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(methods, ","); got != "PUT,DELETE" {
+		t.Fatalf("privacy methods = %s, want PUT,DELETE", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- use go-xsapi/v2 `Block` followed by `Unblock` when `FriendClient.Unfollow` removes a friend
- add request-level regression coverage for the privacy API sequence and block failures

## Root cause

The previous relationship delete removed only JoinLumine's outgoing `follows` edge. An expired player who still followed JoinLumine remained an auto-follow candidate; the next scan followed them again, and the history timestamp was recreated. This allowed the account to remain at the 1,000-friend limit.

The go-xsapi/v2 replacement already exposes [`Block`](https://github.com/HashimTheArab/go-xsapi/blob/main/social/privacy.go) and [`Unblock`](https://github.com/HashimTheArab/go-xsapi/blob/main/social/privacy.go). Xbox documents blocking as removing a user from the caller's friend list, so the immediate unblock clears the relationship without leaving the player blocked.

## Impact

This preserves the existing `FriendClient.Unfollow` call site while changing its removal semantics to clear both sides of a mutual relationship. No configuration change is required.

## Checks

- `go test ./...`
- `go vet ./...`