### PR TITLE
Use mutual follow removal for expiry

### DIFF
--- a/friends.go
+++ b/friends.go
@@ -152,7 +152,7 @@ func (c FriendClient) Follow(ctx context.Context, xuid string) error {
 
 // Unfollow removes the authenticated account's follow relationship for xuid.
 func (c FriendClient) Unfollow(ctx context.Context, xuid string) error {
-	return c.social().Unfollow(ctx, xuid)
+	return c.social().UnfollowLegacy(ctx, xuid)
 }
 
 // ForceUnfollow removes the follow relationship the user identified by xuid

--- a/friends.go
+++ b/friends.go
@@ -150,9 +150,9 @@ func (c FriendClient) Follow(ctx context.Context, xuid string) error {
 	return c.social().Follow(ctx, xuid)
 }
 
-// Unfollow removes the authenticated account's follow relationship for xuid.
+// Unfollow removes the mutual follow relationship with xuid.
 func (c FriendClient) Unfollow(ctx context.Context, xuid string) error {
-	return c.social().UnfollowLegacy(ctx, xuid)
+	return c.social().RemoveMutualFollow(ctx, xuid)
 }
 
 // ForceUnfollow removes the follow relationship the user identified by xuid

--- a/friends_test.go
+++ b/friends_test.go
@@ -28,7 +28,7 @@ func followURL(xuid string) string {
 }
 
 func unfollowURL(xuid string) string {
-	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/friends/v2/xuid(%s)?deleteRelationships=follows", xuid)
+	return fmt.Sprintf("https://social.xboxlive.com/users/me/people/xuid(%s)", xuid)
 }
 
 func TestFriendClientFriendsMergesFollowersAndSocial(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260812030328-18b1a3b9cb7b
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260812035252-bcb6f3204394
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260812030328-18b1a3b9cb7b
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260812030328-18b1a3b9cb7b
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815130220-1dd83707307e

--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ replace (
 	github.com/sandertv/gophertunnel => github.com/hashimthearab/gophertunnel v1.25.3-0.20260812030328-18b1a3b9cb7b
 )
 
-replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884
+replace github.com/df-mc/go-xsapi/v2 => github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee h1:5FtV5/uVOuLmAXM3aGeSdCRMpLRw4KNOuzy4xtXIcmk=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815130220-1dd83707307e h1:2zKmw8RzU0+YL04O8QTJGkhejgxd+Lnu+rQfoGjTsQ0=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815130220-1dd83707307e/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884 h1:aAb6Qxcdcybij9TOKT29gG9F0iJCkky6egI7lnFZmWc=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9 h1:1dahsFvQ4pt7SaXTVQGLEMjhq49yEADFdTbP7w4DEjI=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9 h1:1dahsFvQ4pt7SaXTVQGLEMjhq49yEADFdTbP7w4DEjI=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815121336-afa10c629bb9/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee h1:5FtV5/uVOuLmAXM3aGeSdCRMpLRw4KNOuzy4xtXIcmk=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815125634-6cfb12bda7ee/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260812035252-bcb6f3204394 h1:Tdbsg1eqQU9g+8KVepA8CPFsd8anWOJfITPd8so2SsU=
-github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260812035252-bcb6f3204394/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884 h1:aAb6Qxcdcybij9TOKT29gG9F0iJCkky6egI7lnFZmWc=
+github.com/HashimTheArab/go-xsapi/v2 v2.0.0-20260815120618-a542f9a85884/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=


### PR DESCRIPTION
## Summary

- remove inactive friends through the mutual follow endpoint used by Java MCXboxBroadcast
- keep friend removal to one relationship DELETE instead of a privacy block/unblock sequence
- use the semantic Client.RemoveMutualFollow API from the maintained go-xsapi fork

## Dependencies

- HashimTheArab/go-xsapi#26
- df-mc/go-xsapi#41

## Validation

- go test ./... -count=1
- go vet ./...
- git diff --check

Supersedes #30.