### PR TITLE
fix: allow advertised protocol override

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,6 +123,9 @@ type Status struct {
 	HostName  string
 	WorldName string
 	WorldType string
+	// Protocol is the network protocol advertised in the session document.
+	// Zero uses the protocol library's current protocol.
+	Protocol int32
 	// Version is the game version advertised in the session document.
 	// Clients hide friend worlds whose version is older than their own, so
 	// this may need to lead the compiled-in protocol.CurrentVersion when a

--- a/config_file.go
+++ b/config_file.go
@@ -63,8 +63,11 @@ type ICEPortRangeFile struct {
 }
 
 type SessionInfoFile struct {
-	HostName   string `yaml:"hostName" toml:"hostName"`
-	WorldName  string `yaml:"worldName" toml:"worldName"`
+	HostName  string `yaml:"hostName" toml:"hostName"`
+	WorldName string `yaml:"worldName" toml:"worldName"`
+	// Protocol overrides the network protocol advertised in the session document.
+	// Zero uses the protocol library's current protocol.
+	Protocol   int32  `yaml:"protocol,omitempty" toml:"protocol,omitempty"`
 	Players    int    `yaml:"players" toml:"players"`
 	MaxPlayers int    `yaml:"maxPlayers" toml:"maxPlayers"`
 	IP         string `yaml:"ip" toml:"ip"`
@@ -296,6 +299,7 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 			HostName:         c.Session.SessionInfo.HostName,
 			WorldName:        c.Session.SessionInfo.WorldName,
 			WorldType:        c.Session.WorldType,
+			Protocol:         c.Session.SessionInfo.Protocol,
 			Version:          c.Session.SessionInfo.Version,
 			Players:          c.Session.SessionInfo.Players,
 			MaxPlayers:       c.Session.SessionInfo.MaxPlayers,

--- a/config_file_test.go
+++ b/config_file_test.go
@@ -72,6 +72,8 @@ session:
   sessionInfo:
     hostName: Example Host
     worldName: Example World
+    protocol: 2168
+    version: 1.26.44
     players: 4
     maxPlayers: 32
     ip: ignored.example.net
@@ -126,6 +128,16 @@ accounts:
 	}
 	if cfg.Session.SessionInfo.HostName != "Example Host" || cfg.Session.SessionInfo.MaxPlayers != 32 {
 		t.Fatalf("canonical sessionInfo keys were not loaded: %#v", cfg.Session.SessionInfo)
+	}
+	if cfg.Session.SessionInfo.Protocol != 2168 || cfg.Session.SessionInfo.Version != "1.26.44" {
+		t.Fatalf("canonical advertised protocol/version were not loaded: %#v", cfg.Session.SessionInfo)
+	}
+	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.Status.Protocol != 2168 || runtime.Status.Version != "1.26.44" {
+		t.Fatalf("runtime advertised protocol/version = %d/%q, want 2168/1.26.44", runtime.Status.Protocol, runtime.Status.Version)
 	}
 	if cfg.FriendSync.UpdateInterval != 75 || cfg.FriendSync.AutoFollow || !cfg.FriendSync.AutoUnfollow || cfg.FriendSync.InitialInvite {
 		t.Fatalf("canonical friendSync keys were not loaded: %#v", cfg.FriendSync)

--- a/status.go
+++ b/status.go
@@ -68,7 +68,7 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 		// Always joinable_by_friends, matching MCXboxBroadcast; any other
 		// value makes clients hide the world from the friend list.
 		Joinability:             p2p.JoinabilityFriends,
-		Protocol:                protocol.CurrentProtocol,
+		Protocol:                st.Protocol,
 		Version:                 defaultString(st.Version, protocol.CurrentVersion),
 		TransportLayer:          p2p.TransportLayerNetherNet,
 		LanGame:                 false,

--- a/status_test.go
+++ b/status_test.go
@@ -80,6 +80,29 @@ func TestStatusVersionOverride(t *testing.T) {
 	}
 }
 
+func TestStatusProtocolAndVersionOverride(t *testing.T) {
+	b, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
+		Status: Status{
+			HostName: "Host",
+			Protocol: 2168,
+			Version:  "1.26.44",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := b.status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Protocol != 2168 || status.Version != "1.26.44" {
+		t.Fatalf("advertised protocol/version = %d/%q, want 2168/1.26.44", status.Protocol, status.Version)
+	}
+}
+
 func TestStatusLevelIDUniquePerAccount(t *testing.T) {
 	levelID := func(xuid string) string {
 		b, err := New(Config{


### PR DESCRIPTION
## Summary

- allow the Xbox session document's protocol to be configured alongside its game version
- preserve the current protocol as the default when no override is supplied
- carry the paired override from YAML/TOML config into the runtime broadcaster status

This lets the listener continue accepting 26.40-26.45 while the friends-list card advertises the version currently available to players.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional protocol setting to session configuration.
  * Status announcements now report the configured protocol and version values.
  * The default protocol remains available when no override is specified.

* **Bug Fixes**
  * Fixed status reporting so configured protocol overrides are preserved and advertised correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->