### PR TITLE
feat: relay mode keeps players in the NetherNet session

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ The config exposes the same operator-facing areas as MCXboxBroadcast:
 - optional HTTP proxy URL through `http.proxy`
 - selectable NetherNet signaling through `session.signalingMode`: `websocket`
   (default) or `jsonrpc` (only when no sub-accounts are enabled).
+- relay mode through `relay.enabled`, which keeps players inside the NetherNet
+  session instead of transferring them (see below).
+
+### Relay mode
+
+By default a joining client receives a `Transfer` to `sessionInfo.ip:port` and
+leaves the Xbox session, so only the bot's own friends ever see the world. With
+`relay.enabled: true` the broadcaster instead logs the player into the backend
+itself and relays every packet batch in both directions. The player stays a
+member of the session for as long as they play, which lets their own friends
+discover and join the world too. The backend owns the whole login sequence,
+including resource packs, so the client sees exactly what a direct join would.
+
+The backend receives the relay's address and a self-signed login chain that
+still carries the XUID the broadcaster verified, so it must trust the relay:
+Geyser with `advanced.bedrock.validate-bedrock-login: false`, BDS with
+`online-mode=false`, or a gophertunnel listener with `AuthenticationDisabled`.
+Bind such a backend to loopback or a private network; the broadcaster is its
+authentication boundary. Public servers that verify login chains cannot be
+relayed to, and a `Transfer` sent by the backend still moves the client out of
+the session.
+
+Library users can route each player individually with `RelayConfig.ResolveTarget`
+and customize the backend dial with `RelayConfig.Dialer`. Xbox Live's session
+member limit bounds how many players one session can relay at a time.
 
 ### Signaling modes
 

--- a/broadcaster.go
+++ b/broadcaster.go
@@ -72,6 +72,10 @@ type Broadcaster struct {
 	lastQuery *minecraft.ServerStatus
 
 	transferCloseTimeout time.Duration
+	// relays tracks clients currently relayed to the backend.
+	relays relaySet
+	// relayDial overrides the backend dial; nil dials with the configured Dialer.
+	relayDial relayDialFunc
 	// subAccountStartTimeout bounds each sub-account's session publish so a hung
 	// directory or RTA call degrades to a skipped sub-account instead of
 	// blocking broadcaster startup. Zero uses the default.
@@ -120,6 +124,9 @@ type defaultSignalingConfig struct {
 // New validates conf and returns a Broadcaster.
 func New(conf Config) (*Broadcaster, error) {
 	if err := conf.Server.validate(); err != nil {
+		return nil, err
+	}
+	if err := conf.Relay.validate(); err != nil {
 		return nil, err
 	}
 	mode, err := normalizeSignalingMode(conf.SignalingMode)
@@ -441,7 +448,17 @@ func (b *Broadcaster) minecraftListenConfig(status room.Status) minecraft.Listen
 			minecraft.Protocol12644(),
 		}
 	}
-	conf.CompressionThreshold = -1
+	if b.conf.Relay != nil {
+		// Accept right after login so the backend owns the rest of the login
+		// sequence, including resource packs, end to end with the real client.
+		conf.DisablePacketHandling = true
+		conf.EnableBatchReading = true
+		conf.FlushRate = -1 // relayPump flushes once per forwarded batch
+		conf.AllowUnknownPackets = true
+		conf.AllowInvalidPackets = true
+	} else {
+		conf.CompressionThreshold = -1
+	}
 	conf.ForceDisableVibrantVisuals = true
 	conf.ResourcePackWorldTemplateUUID = uuid.Nil
 	conf.ResourcePackWorldTemplateVersion = ""
@@ -1368,7 +1385,7 @@ func (b *Broadcaster) notifySessionUpdateFailure(ctx context.Context, err error)
 	b.notify(ctx, "Xbox session update failed: "+err.Error())
 }
 
-// acceptListener accepts connections from the given listener and transfers each to the target server.
+// acceptListener accepts connections from the given listener and hands each to handleClient.
 func (b *Broadcaster) acceptListener(l *minecraft.Listener) {
 	for {
 		conn, err := l.Accept()
@@ -1384,7 +1401,7 @@ func (b *Broadcaster) acceptListener(l *minecraft.Listener) {
 			_ = conn.Close()
 			continue
 		}
-		go b.transfer(mcConn)
+		go b.handleClient(mcConn)
 	}
 }
 
@@ -1681,8 +1698,8 @@ func (b *Broadcaster) sessionHealthIssue() sessionHealthIssue {
 	if session.Context().Err() != nil {
 		return sessionHealthIssue{reason: "mpsd session lost"}
 	}
-	if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
-		return sessionHealthIssue{reason: fmt.Sprintf("session has %d/30 members", count)}
+	if count := b.staleSessionMembers(session.Members()); count >= sessionMemberRestartThreshold {
+		return sessionHealthIssue{reason: fmt.Sprintf("session has %d/30 non-relayed members", count)}
 	}
 	for _, sub := range b.subAnnouncers {
 		xbl, ok := xblAnnouncer(sub.announcer)
@@ -1696,24 +1713,15 @@ func (b *Broadcaster) sessionHealthIssue() sessionHealthIssue {
 			return sessionHealthIssue{reason: "sub-account session lost", subAccountID: sub.id}
 		}
 		if session != nil {
-			if count := sessionMemberCount(session); count >= sessionMemberRestartThreshold {
+			if count := b.staleSessionMembers(session.Members()); count >= sessionMemberRestartThreshold {
 				return sessionHealthIssue{
-					reason:       fmt.Sprintf("sub-account session has %d/30 members", count),
+					reason:       fmt.Sprintf("sub-account session has %d/30 non-relayed members", count),
 					subAccountID: sub.id,
 				}
 			}
 		}
 	}
 	return sessionHealthIssue{}
-}
-
-// sessionMemberCount counts the members of an MPSD session.
-func sessionMemberCount(session *mpsd.Session) int {
-	count := 0
-	for range session.Members() {
-		count++
-	}
-	return count
 }
 
 // recreateAfterFailure rebuilds the whole session stack after a health-check

--- a/config.example.yml
+++ b/config.example.yml
@@ -47,6 +47,13 @@ gallery:
   imagePath: screenshot.jpg
   deleteOtherImages: true
 
+# Keep joined players inside the NetherNet session and relay their traffic to
+# sessionInfo.ip:port instead of transferring them. Players stay session
+# members while they play, so their friends can discover the world too. The
+# backend must trust this relay's unsigned login chain (see README).
+relay:
+  enabled: false
+
 accounts:
   primaryCachePath: cache/live_token.json
   subAccounts: []

--- a/config.go
+++ b/config.go
@@ -31,8 +31,11 @@ type Config struct {
 	// signaling and gallery/profile image requests.
 	MinecraftTokenSource service.TokenSource
 
-	// Server is the target Bedrock server clients are transferred to.
+	// Server is the target Bedrock server clients are transferred or relayed to.
 	Server ServerInfo
+	// Relay keeps joined clients inside the NetherNet session and relays them
+	// to the backend instead of transferring them. Nil transfers.
+	Relay *RelayConfig
 
 	// SessionName is the MPSD session name. If empty, a random UUID is used.
 	SessionName string

--- a/config_file.go
+++ b/config_file.go
@@ -31,6 +31,7 @@ type ConfigFile struct {
 	FriendSync                   FriendFileConfig   `yaml:"friendSync" toml:"friendSync"`
 	Notifications                NotificationConfig `yaml:"notifications" toml:"notifications"`
 	Gallery                      GalleryFileConfig  `yaml:"gallery" toml:"gallery"`
+	Relay                        RelayFileConfig    `yaml:"relay" toml:"relay"`
 	Accounts                     AccountsConfig     `yaml:"accounts" toml:"accounts"`
 
 	// Notes lists adjustments applied while loading, such as out-of-range
@@ -97,6 +98,11 @@ type FriendExpiryFile struct {
 type NotificationConfig struct {
 	Enabled    bool   `yaml:"enabled" toml:"enabled"`
 	WebhookURL string `yaml:"webhookUrl" toml:"webhookUrl"`
+}
+
+// RelayFileConfig enables relay mode; see RelayConfig for the trust model.
+type RelayFileConfig struct {
+	Enabled bool `yaml:"enabled" toml:"enabled"`
 }
 
 type GalleryFileConfig struct {
@@ -322,6 +328,9 @@ func (c ConfigFile) RuntimeConfig(in RuntimeConfigInput) (Config, error) {
 	}
 	if c.FriendSync.Expiry.Enabled {
 		cfg.FriendHistory = NewFileHistoryStore(resolvePath(in.BaseDir, c.FriendSync.Expiry.HistoryPath))
+	}
+	if c.Relay.Enabled {
+		cfg.Relay = &RelayConfig{}
 	}
 	if c.Gallery.Enabled {
 		cfg.Gallery = &GalleryConfig{

--- a/relay.go
+++ b/relay.go
@@ -1,0 +1,274 @@
+package broadcaster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/df-mc/go-xsapi/v2/mpsd"
+	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+	"github.com/sandertv/gophertunnel/minecraft/text"
+)
+
+const defaultRelayDialTimeout = 15 * time.Second
+
+// RelayConfig keeps joined clients inside the NetherNet session and relays
+// their traffic to the backend server instead of transferring them. A relayed
+// player stays a member of the Xbox session for as long as they play, which is
+// what lets friends of that player discover the world. Xbox Live's session
+// member limit therefore bounds concurrent relayed players.
+//
+// The backend sees the relay's address and an unsigned login chain that still
+// carries the player's verified XUID, so it must trust this relay: Geyser with
+// validate-bedrock-login off, BDS with online-mode off, or a gophertunnel
+// listener with AuthenticationDisabled. Public servers that verify chains
+// cannot be relayed to.
+type RelayConfig struct {
+	// ResolveTarget picks the backend address for a client. Nil relays every
+	// client to Config.Server.
+	ResolveTarget func(ctx context.Context, identity login.IdentityData, client login.ClientData) (string, error)
+	// Network is the gophertunnel network used to dial the backend. Empty uses "raknet".
+	Network string
+	// Dialer customizes the backend dial. It must not authenticate: identity,
+	// client data, protocol, and passthrough settings are set per client.
+	Dialer minecraft.Dialer
+	// DialTimeout bounds target resolution plus the backend dial. Zero uses 15s.
+	DialTimeout time.Duration
+}
+
+func (c *RelayConfig) validate() error {
+	if c == nil {
+		return nil
+	}
+	if c.Dialer.TokenSource != nil || c.Dialer.XBLClient != nil || c.Dialer.PlayFabClient != nil {
+		return errors.New("relay dialer must not authenticate; the relay logs in with each client's identity")
+	}
+	return nil
+}
+
+func (c *RelayConfig) dialTimeout() time.Duration {
+	if c.DialTimeout <= 0 {
+		return defaultRelayDialTimeout
+	}
+	return c.DialTimeout
+}
+
+func (c *RelayConfig) network() string {
+	if c.Network == "" {
+		return "raknet"
+	}
+	return c.Network
+}
+
+// relayClientConn is the accepted client surface the relay needs; *minecraft.Conn satisfies it.
+type relayClientConn interface {
+	transferConn
+	relayServerConn
+	ClientData() login.ClientData
+	Proto() minecraft.Protocol
+}
+
+// relayServerConn is the batch surface relayed between the two legs.
+type relayServerConn interface {
+	ReadBatch() ([]packet.Packet, error)
+	WritePacket(packet.Packet) error
+	Flush() error
+	Close() error
+}
+
+// relayDialFunc dials the backend for one client. The broadcaster's default uses d.DialContext.
+type relayDialFunc func(ctx context.Context, d minecraft.Dialer, network, address string) (relayServerConn, error)
+
+// relaySet tracks the clients being relayed so session health can tell their
+// live memberships from stale ones.
+type relaySet struct {
+	mu      sync.Mutex
+	clients map[relayClientConn]string // conn -> XUID
+}
+
+func (s *relaySet) add(conn relayClientConn, xuid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.clients == nil {
+		s.clients = make(map[relayClientConn]string)
+	}
+	s.clients[conn] = xuid
+}
+
+func (s *relaySet) remove(conn relayClientConn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.clients, conn)
+}
+
+func (s *relaySet) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.clients)
+}
+
+// xuids returns the set of XUIDs currently being relayed.
+func (s *relaySet) xuids() map[string]struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	xuids := make(map[string]struct{}, len(s.clients))
+	for _, xuid := range s.clients {
+		xuids[xuid] = struct{}{}
+	}
+	return xuids
+}
+
+// staleSessionMembers counts session members that are not being relayed. In
+// transfer mode that is every member; relayed members are live players, not
+// leftovers that block joiners.
+func (b *Broadcaster) staleSessionMembers(members iter.Seq2[string, mpsd.MemberDescription]) int {
+	relayed := b.relays.xuids()
+	count := 0
+	for _, member := range members {
+		if member.Constants != nil && member.Constants.System != nil {
+			if _, ok := relayed[member.Constants.System.XUID]; ok {
+				continue
+			}
+		}
+		count++
+	}
+	return count
+}
+
+// handleClient relays conn when relay mode is configured and transfers it otherwise.
+func (b *Broadcaster) handleClient(conn relayClientConn) {
+	if b.conf.Relay == nil {
+		b.transfer(conn)
+		return
+	}
+	b.relay(conn)
+}
+
+// relay logs conn's player into the backend with their own identity and pumps
+// packets both ways until either side disconnects.
+func (b *Broadcaster) relay(conn relayClientConn) {
+	cfg := b.conf.Relay
+	id := conn.IdentityData()
+	b.relays.add(conn, id.XUID)
+	defer b.relays.remove(conn)
+	defer conn.Close()
+
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, cfg.dialTimeout())
+	target, err := b.resolveRelayTarget(dialCtx, id, conn.ClientData())
+	if err != nil {
+		cancel()
+		b.log.Error("resolve relay target", "xuid", id.XUID, "name", id.DisplayName, "err", err)
+		b.disconnectRelayClient(conn, "The server is not available right now.")
+		return
+	}
+	server, err := b.dialRelayTarget(dialCtx, conn, target)
+	cancel()
+	if err != nil {
+		b.log.Error("dial relay target", "xuid", id.XUID, "name", id.DisplayName, "target", target, "err", err)
+		b.disconnectRelayClient(conn, "Could not reach the server, try again shortly.")
+		return
+	}
+	defer server.Close()
+
+	if recorder, ok := b.conf.FriendHistory.(HistoryRecorder); ok && id.XUID != "" {
+		if err := recorder.Seen(ctx, id.XUID, time.Now()); err != nil {
+			b.log.Error("record player history", "xuid", id.XUID, "err", err)
+		}
+	}
+	b.info("relaying bedrock client", "xuid", id.XUID, "name", id.DisplayName, "target", target)
+
+	errs := make(chan error, 2)
+	go func() { errs <- relayPump(conn, server) }()
+	go func() { errs <- relayPump(server, conn) }()
+	select {
+	case err := <-errs:
+		if err != nil && !errors.Is(err, net.ErrClosed) {
+			b.debug("relay ended", "xuid", id.XUID, "name", id.DisplayName, "err", err)
+		}
+	case <-ctx.Done():
+	}
+}
+
+func (b *Broadcaster) resolveRelayTarget(ctx context.Context, id login.IdentityData, client login.ClientData) (string, error) {
+	if b.conf.Relay.ResolveTarget == nil {
+		return b.conf.Server.Address(), nil
+	}
+	target, err := b.conf.Relay.ResolveTarget(ctx, id, client)
+	if err != nil {
+		return "", err
+	}
+	if target == "" {
+		return "", errors.New("resolver returned an empty target")
+	}
+	return target, nil
+}
+
+// dialRelayTarget dials target with the client's identity and client data.
+// The backend cannot encrypt to the client's key, so the login chain is
+// self-signed while keeping the XUID the listener already verified.
+func (b *Broadcaster) dialRelayTarget(ctx context.Context, conn relayClientConn, target string) (relayServerConn, error) {
+	cfg := b.conf.Relay
+	d := cfg.Dialer
+	d.IdentityData = conn.IdentityData()
+	d.ClientData = conn.ClientData()
+	d.ClientData.ServerAddress = target
+	d.KeepXBLIdentityData = true
+	d.DisablePacketHandling = true
+	d.EnableBatchReading = true
+	d.FlushRate = -1 // relayPump flushes once per forwarded batch
+	d.Protocol = conn.Proto()
+	if d.ErrorLog == nil {
+		d.ErrorLog = b.log
+	}
+	dial := b.relayDial
+	if dial == nil {
+		dial = defaultRelayDial
+	}
+	server, err := dial(ctx, d, cfg.network(), target)
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+func defaultRelayDial(ctx context.Context, d minecraft.Dialer, network, address string) (relayServerConn, error) {
+	conn, err := d.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (b *Broadcaster) disconnectRelayClient(conn relayClientConn, message string) {
+	_ = conn.WritePacket(&packet.Disconnect{Message: text.Colourf("<red>%v</red>", message)})
+	_ = conn.Flush()
+}
+
+// relayPump forwards each network batch read from src as one batch to dst, so
+// the relay adds no coalescing latency of its own.
+func relayPump(src, dst relayServerConn) error {
+	for {
+		batch, err := src.ReadBatch()
+		if err != nil {
+			return fmt.Errorf("read batch: %w", err)
+		}
+		for _, pk := range batch {
+			if err := dst.WritePacket(pk); err != nil {
+				return fmt.Errorf("write packet: %w", err)
+			}
+		}
+		if err := dst.Flush(); err != nil {
+			return fmt.Errorf("flush batch: %w", err)
+		}
+	}
+}

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,0 +1,392 @@
+package broadcaster
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/df-mc/go-xsapi/v2/mpsd"
+	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+	"github.com/sandertv/gophertunnel/minecraft/room"
+	"golang.org/x/oauth2"
+)
+
+type relayOAuthTokenSource struct{}
+
+func (relayOAuthTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: "token"}, nil
+}
+
+// fakeRelayConn serves scripted batches and records what the relay writes.
+type fakeRelayConn struct {
+	mu       sync.Mutex
+	batches  chan []packet.Packet
+	written  []packet.Packet
+	flushes  int
+	closed   chan struct{}
+	identity login.IdentityData
+	client   login.ClientData
+}
+
+func newFakeRelayConn(batches ...[]packet.Packet) *fakeRelayConn {
+	c := &fakeRelayConn{batches: make(chan []packet.Packet, len(batches)), closed: make(chan struct{})}
+	for _, batch := range batches {
+		c.batches <- batch
+	}
+	return c
+}
+
+func (c *fakeRelayConn) ReadBatch() ([]packet.Packet, error) {
+	select {
+	case batch := <-c.batches:
+		return batch, nil
+	case <-c.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (c *fakeRelayConn) WritePacket(pk packet.Packet) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.written = append(c.written, pk)
+	return nil
+}
+
+func (c *fakeRelayConn) Flush() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.flushes++
+	return nil
+}
+
+func (c *fakeRelayConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return nil
+}
+
+func (c *fakeRelayConn) ReadPacket() (packet.Packet, error) { return nil, net.ErrClosed }
+func (c *fakeRelayConn) SetReadDeadline(time.Time) error    { return nil }
+func (c *fakeRelayConn) IdentityData() login.IdentityData   { return c.identity }
+func (c *fakeRelayConn) ClientData() login.ClientData       { return c.client }
+func (c *fakeRelayConn) Proto() minecraft.Protocol          { return minecraft.DefaultProtocol }
+func (c *fakeRelayConn) isClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
+}
+func (c *fakeRelayConn) snapshot() ([]packet.Packet, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]packet.Packet(nil), c.written...), c.flushes
+}
+func (c *fakeRelayConn) waitClosed(t *testing.T, what string) {
+	t.Helper()
+	select {
+	case <-c.closed:
+	case <-time.After(time.Second):
+		t.Fatalf("%s was not closed", what)
+	}
+}
+
+func relayTestBroadcaster(relay *RelayConfig, dial relayDialFunc) *Broadcaster {
+	return &Broadcaster{
+		log:       testBroadcasterLogger(),
+		conf:      Config{Server: ServerInfo{Host: "backend.example.net", Port: 19133}, Relay: relay},
+		relayDial: dial,
+	}
+}
+
+func TestRelayPumpForwardsEachBatchWithOneFlush(t *testing.T) {
+	first := []packet.Packet{&packet.Text{Message: "a"}, &packet.Text{Message: "b"}}
+	second := []packet.Packet{&packet.Text{Message: "c"}}
+	src := newFakeRelayConn(first, second)
+	dst := newFakeRelayConn()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		src.Close()
+	}()
+
+	err := relayPump(src, dst)
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("pump error = %v, want net.ErrClosed", err)
+	}
+	written, flushes := dst.snapshot()
+	if len(written) != 3 || flushes != 2 {
+		t.Fatalf("forwarded %d packets with %d flushes, want 3 packets and 2 flushes", len(written), flushes)
+	}
+}
+
+func TestBroadcasterRelayDialsWithClientIdentityAndForwardsBothWays(t *testing.T) {
+	client := newFakeRelayConn([]packet.Packet{&packet.Text{Message: "from client"}})
+	client.identity = login.IdentityData{XUID: "visitor", DisplayName: "Visitor"}
+	client.client = login.ClientData{GameVersion: "1.26.45", ServerAddress: "nethernet"}
+	server := newFakeRelayConn([]packet.Packet{&packet.Text{Message: "from server"}})
+
+	var (
+		gotDialer  minecraft.Dialer
+		gotNetwork string
+		gotAddress string
+	)
+	b := relayTestBroadcaster(&RelayConfig{}, func(_ context.Context, d minecraft.Dialer, network, address string) (relayServerConn, error) {
+		gotDialer, gotNetwork, gotAddress = d, network, address
+		return server, nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		b.relay(client)
+		close(done)
+	}()
+	// Both legs forwarded their batch; ending the server leg tears the relay down.
+	waitFor(t, func() bool {
+		cw, _ := client.snapshot()
+		sw, _ := server.snapshot()
+		return len(cw) == 1 && len(sw) == 1
+	}, "batches were not forwarded both ways")
+	if b.relays.count() != 1 {
+		t.Fatalf("relayed clients = %d, want 1 while active", b.relays.count())
+	}
+	server.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("relay did not stop after the server closed")
+	}
+	client.waitClosed(t, "client")
+
+	if gotNetwork != "raknet" || gotAddress != "backend.example.net:19133" {
+		t.Fatalf("dialed %s %s, want raknet backend.example.net:19133", gotNetwork, gotAddress)
+	}
+	if gotDialer.IdentityData.XUID != "visitor" || !gotDialer.KeepXBLIdentityData {
+		t.Fatalf("dialer identity %#v keep=%v, want the client's XUID kept", gotDialer.IdentityData, gotDialer.KeepXBLIdentityData)
+	}
+	if gotDialer.ClientData.GameVersion != "1.26.45" || gotDialer.ClientData.ServerAddress != "backend.example.net:19133" {
+		t.Fatalf("dialer client data %#v, want the client's data pointed at the backend", gotDialer.ClientData)
+	}
+	if !gotDialer.DisablePacketHandling || !gotDialer.EnableBatchReading || gotDialer.FlushRate != -1 {
+		t.Fatalf("dialer passthrough flags = %v/%v/%v, want passthrough batch reading with relay-owned flushing", gotDialer.DisablePacketHandling, gotDialer.EnableBatchReading, gotDialer.FlushRate)
+	}
+	if gotDialer.Protocol == nil || gotDialer.Protocol.ID() != minecraft.DefaultProtocol.ID() {
+		t.Fatalf("dialer protocol %v, want the client's", gotDialer.Protocol)
+	}
+	if b.relays.count() != 0 {
+		t.Fatalf("relayed clients = %d after the relay ended, want 0", b.relays.count())
+	}
+}
+
+func TestBroadcasterRelayUsesResolvedTarget(t *testing.T) {
+	client := newFakeRelayConn()
+	client.identity = login.IdentityData{XUID: "visitor"}
+	server := newFakeRelayConn()
+	server.Close()
+
+	var gotAddress string
+	b := relayTestBroadcaster(&RelayConfig{
+		Network: "nethernet",
+		ResolveTarget: func(_ context.Context, id login.IdentityData, _ login.ClientData) (string, error) {
+			return "instance-" + id.XUID + ":19140", nil
+		},
+	}, func(_ context.Context, _ minecraft.Dialer, network, address string) (relayServerConn, error) {
+		if network != "nethernet" {
+			t.Errorf("network = %s, want nethernet", network)
+		}
+		gotAddress = address
+		return server, nil
+	})
+
+	b.relay(client)
+	if gotAddress != "instance-visitor:19140" {
+		t.Fatalf("dialed %q, want the resolved per-client target", gotAddress)
+	}
+}
+
+func TestBroadcasterRelayDisconnectsClientWhenTargetResolutionFails(t *testing.T) {
+	client := newFakeRelayConn()
+	dialed := false
+	b := relayTestBroadcaster(&RelayConfig{
+		ResolveTarget: func(context.Context, login.IdentityData, login.ClientData) (string, error) {
+			return "", errors.New("no session")
+		},
+	}, func(context.Context, minecraft.Dialer, string, string) (relayServerConn, error) {
+		dialed = true
+		return nil, nil
+	})
+
+	b.relay(client)
+	if dialed {
+		t.Fatal("backend was dialed without a target")
+	}
+	assertDisconnected(t, client)
+}
+
+func TestBroadcasterRelayDisconnectsClientWhenDialFails(t *testing.T) {
+	client := newFakeRelayConn()
+	b := relayTestBroadcaster(&RelayConfig{}, func(context.Context, minecraft.Dialer, string, string) (relayServerConn, error) {
+		return nil, errors.New("connection refused")
+	})
+
+	b.relay(client)
+	assertDisconnected(t, client)
+	if b.relays.count() != 0 {
+		t.Fatalf("relayed clients = %d after a failed dial, want 0", b.relays.count())
+	}
+}
+
+func assertDisconnected(t *testing.T, client *fakeRelayConn) {
+	t.Helper()
+	written, flushes := client.snapshot()
+	if len(written) != 1 {
+		t.Fatalf("client received %d packets, want one Disconnect", len(written))
+	}
+	if _, ok := written[0].(*packet.Disconnect); !ok {
+		t.Fatalf("client received %T, want Disconnect", written[0])
+	}
+	if flushes == 0 || !client.isClosed() {
+		t.Fatalf("disconnect flushed=%d closed=%v, want flushed and closed", flushes, client.isClosed())
+	}
+}
+
+func TestHandleClientTransfersWithoutRelayConfig(t *testing.T) {
+	client := newFakeRelayConn()
+	b := relayTestBroadcaster(nil, func(context.Context, minecraft.Dialer, string, string) (relayServerConn, error) {
+		t.Fatal("backend dialed in transfer mode")
+		return nil, nil
+	})
+	b.transferCloseTimeout = -1
+
+	b.handleClient(client)
+	written, _ := client.snapshot()
+	var transferred bool
+	for _, pk := range written {
+		if _, ok := pk.(*packet.Transfer); ok {
+			transferred = true
+		}
+	}
+	if !transferred {
+		t.Fatalf("client was not transferred: %#v", written)
+	}
+}
+
+func TestStaleSessionMembersIgnoresRelayedPlayers(t *testing.T) {
+	b := relayTestBroadcaster(&RelayConfig{}, nil)
+	live := newFakeRelayConn()
+	b.relays.add(live, "relayed")
+
+	members := func(yield func(string, mpsd.MemberDescription) bool) {
+		for _, xuid := range []string{"relayed", "stale", "host"} {
+			if !yield(xuid, mpsd.MemberDescription{Constants: &mpsd.MemberConstants{System: &mpsd.MemberConstantsSystem{XUID: xuid}}}) {
+				return
+			}
+		}
+		yield("anonymous", mpsd.MemberDescription{})
+	}
+	if got := b.staleSessionMembers(iter.Seq2[string, mpsd.MemberDescription](members)); got != 3 {
+		t.Fatalf("stale members = %d, want 3 (everyone but the relayed player)", got)
+	}
+	b.relays.remove(live)
+	if got := b.staleSessionMembers(iter.Seq2[string, mpsd.MemberDescription](members)); got != 4 {
+		t.Fatalf("stale members = %d after the relay ended, want 4", got)
+	}
+}
+
+func TestMinecraftListenConfigRelayModeUsesPassthroughBatches(t *testing.T) {
+	b := relayTestBroadcaster(&RelayConfig{}, nil)
+	conf := b.minecraftListenConfig(room.Status{})
+	if !conf.DisablePacketHandling || !conf.EnableBatchReading || conf.FlushRate != -1 {
+		t.Fatalf("relay listen config = handling off %v, batches %v, flush %v; want passthrough batch reading with relay-owned flushing", conf.DisablePacketHandling, conf.EnableBatchReading, conf.FlushRate)
+	}
+	if !conf.AllowUnknownPackets || !conf.AllowInvalidPackets {
+		t.Fatal("relay listen config must pass unknown and invalid packets through")
+	}
+	if conf.CompressionThreshold == -1 {
+		t.Fatal("relay listen config should keep compression for gameplay traffic")
+	}
+
+	b.conf.Relay = nil
+	conf = b.minecraftListenConfig(room.Status{})
+	if conf.DisablePacketHandling || conf.EnableBatchReading || conf.CompressionThreshold != -1 {
+		t.Fatalf("transfer listen config changed: %#v", conf)
+	}
+}
+
+func TestStatusReportsRelayedPlayersWhenNotQuerying(t *testing.T) {
+	b, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
+		Relay:          &RelayConfig{},
+		Status:         Status{Players: 1, MaxPlayers: 20},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		b.relays.add(newFakeRelayConn(), string(rune('a'+i)))
+	}
+	status, err := b.status(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MemberCount != 3 {
+		t.Fatalf("member count = %d, want the 3 relayed players", status.MemberCount)
+	}
+}
+
+func TestNewRejectsAuthenticatingRelayDialer(t *testing.T) {
+	_, err := New(Config{
+		XBLTokenSource: staticTokenSource{},
+		XUID:           "123",
+		Server:         ServerInfo{Host: "127.0.0.1", Port: 19132},
+		Relay:          &RelayConfig{Dialer: minecraft.Dialer{TokenSource: relayOAuthTokenSource{}}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for a relay dialer that authenticates as the bot")
+	}
+}
+
+func TestConfigFileMapsRelay(t *testing.T) {
+	cfg := DefaultConfigFile()
+	runtime, err := cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.Relay != nil {
+		t.Fatal("relay mode enabled by default")
+	}
+
+	cfg.Relay.Enabled = true
+	runtime, err = cfg.RuntimeConfig(RuntimeConfigInput{XBLTokenSource: staticTokenSource{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.Relay == nil {
+		t.Fatal("relay.enabled was not mapped")
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/status.go
+++ b/status.go
@@ -57,6 +57,9 @@ func (b *Broadcaster) status(ctx context.Context) (room.Status, error) {
 		}
 	}
 
+	if b.conf.Relay != nil && !st.QueryTarget {
+		st.Players = max(st.Players, b.relays.count())
+	}
 	advertisedProtocol := st.Protocol
 	if advertisedProtocol == 0 {
 		advertisedProtocol = protocol.CurrentProtocol


### PR DESCRIPTION
## Summary

Adds a relay mode so joining players stay inside the bot's NetherNet session instead of being transferred to the target server. A relayed player remains a member of the Xbox session while they play, which is what lets *their* friends discover and join the world (friends-of-friends), the thing the `StartGame` + `Transfer` redirect could never do. This is the behaviour [ezchr/nether2rak](https://github.com/ezchr/nether2rak) implements standalone.

## How it works

- `Config.Relay` (`relay.enabled` in the config file) switches the accept path from `transfer()` to `relay()`.
- The listener accepts the client right after `Login` (`DisablePacketHandling`), and the backend is dialed with the client's own `IdentityData`/`ClientData` over a self-signed chain that keeps the verified XUID (`KeepXBLIdentityData`). The backend then drives the rest of the login sequence, including resource packs, end to end with the real client.
- Both legs use `EnableBatchReading` with `FlushRate = -1`; `relayPump` forwards each network batch as one batch and flushes once per batch, the same model as Lunar's relay, so no coalescing latency is added.
- `RelayConfig.ResolveTarget` lets an embedder route each player to their own backend (mobile-server can resolve the per-user proxy port directly instead of going through the redirector). `RelayConfig.Dialer` customizes the backend dial and must not authenticate.
- Session health now counts only members that are *not* being relayed towards the 28/30 restart threshold, since relayed members are live players rather than stale leftovers. Status reports the relayed player count when the target is not queried.

## Trust model

The backend sees the relay's address and an unsigned chain, so it must trust the relay (Geyser `validate-bedrock-login: false`, BDS `online-mode=false`, gophertunnel `AuthenticationDisabled`) and should be bound to loopback or a private network. Public servers that verify chains cannot be relayed to. A `Transfer` sent by the backend is forwarded as-is and still moves the client out of the session. Xbox Live's session member limit bounds concurrent relayed players; there is deliberately no client cap or overflow transfer in the broadcaster.

## Testing

- `go test -race ./...` passes.
- New tests cover the batch pump (one flush per batch), dialer identity/passthrough settings, `ResolveTarget` routing and failure disconnects, transfer fallback when relay is off, stale-member counting, listener config in relay mode, status member count, and config-file mapping.
- Not yet verified on-device: a real client joining through the friends tab and playing through a relayed backend. That needs a bot account plus a trusted backend and is the next step before enabling it in any deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Relay mode to keep players in the NetherNet session while forwarding gameplay traffic to a backend server.
  - Added configuration options for enabling Relay mode and customizing backend connection behavior.
  - Relay-connected players remain visible in session status and are excluded from stale-member health checks.

- **Documentation**
  - Documented Relay mode setup, backend trust requirements, limitations, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->